### PR TITLE
Give producer opportunity to clear its queue before closing

### DIFF
--- a/forwarder/kafka/kafka_producer.py
+++ b/forwarder/kafka/kafka_producer.py
@@ -19,6 +19,8 @@ class KafkaProducer:
     def close(self):
         self._cancelled = True
         self._poll_thread.join()
+        max_wait_to_publish_producer_queue = 2  # seconds
+        self._producer.flush(max_wait_to_publish_producer_queue)
 
     def produce(
         self, topic: str, payload: bytes, timestamp_ms: int, key: Optional[str] = None,


### PR DESCRIPTION
Solves a problem I saw when using the manual test scripts where occasionally the producer was closed before it had published a message.