### PR TITLE
Use caproto "time" data_type to get time and alarm info

### DIFF
--- a/forwarder/epics_to_serialisable_types.py
+++ b/forwarder/epics_to_serialisable_types.py
@@ -13,14 +13,13 @@ from p4p.nt.scalar import ntbool, ntfloat, ntint, ntstr, ntstringarray
 # Unfortunately the serialisation method doesn't know what to do with such a specific dtype
 # so we will cast to a consistent type based on the EPICS channel type.
 numpy_type_from_channel_type = {
-    ChannelType.CTRL_INT: np.int32,
-    ChannelType.CTRL_LONG: np.int64,
-    ChannelType.CTRL_FLOAT: np.float32,
-    ChannelType.CTRL_DOUBLE: np.float64,
-    ChannelType.CTRL_STRING: np.unicode_,
-    ChannelType.CTRL_ENUM: np.int32,
-    ChannelType.CTRL_CHAR: np.unicode_,
+    ChannelType.TIME_INT: np.int32,
+    ChannelType.TIME_LONG: np.int64,
+    ChannelType.TIME_FLOAT: np.float32,
+    ChannelType.TIME_DOUBLE: np.float64,
     ChannelType.TIME_STRING: np.unicode_,
+    ChannelType.TIME_ENUM: np.int32,
+    ChannelType.TIME_CHAR: np.unicode_,
     ntenum: np.int32,
     ntbool: np.bool,
     ntfloat: np.float64,

--- a/forwarder/kafka/kafka_producer.py
+++ b/forwarder/kafka/kafka_producer.py
@@ -27,7 +27,6 @@ class KafkaProducer:
             if err:
                 self.logger.error(f"Message failed delivery: {err}")
 
-        self.logger.info(f"Producing with timestamp: {timestamp_ms}")
         self._producer.produce(
             topic, payload, key=key, on_delivery=ack, timestamp=timestamp_ms
         )


### PR DESCRIPTION
Closes #10

Before: used system time when the monitor callback triggered as the timestamp for CA PV updates.
After: Uses timestamp from EPICS