### PR TITLE
Add unit tests for StatusReporter

### DIFF
--- a/forwarder/status_reporter.py
+++ b/forwarder/status_reporter.py
@@ -1,5 +1,5 @@
-from forwarder.kafka.kafka_helpers import create_producer
 from forwarder.repeat_timer import RepeatTimer, milliseconds_to_seconds
+from forwarder.kafka.kafka_producer import KafkaProducer
 from typing import Dict
 import json
 import time
@@ -7,12 +7,16 @@ import time
 
 class StatusReporter:
     def __init__(
-        self, update_handlers: Dict, broker: str, topic: str, interval_ms: int = 4000
+        self,
+        update_handlers: Dict,
+        producer: KafkaProducer,
+        topic: str,
+        interval_ms: int = 4000,
     ):
         self._repeating_timer = RepeatTimer(
             milliseconds_to_seconds(interval_ms), self.report_status
         )
-        self._producer = create_producer(broker)
+        self._producer = producer
         self._topic = topic
         self._update_handlers = update_handlers
 

--- a/forwarder_launch.py
+++ b/forwarder_launch.py
@@ -158,7 +158,9 @@ if __name__ == "__main__":
     consumer.subscribe([config_topic])
 
     status_broker, status_topic = get_broker_and_topic_from_uri(args.status_topic)
-    status_reporter = StatusReporter(update_handlers, status_broker, status_topic)
+    status_reporter = StatusReporter(
+        update_handlers, create_producer(status_broker), status_topic
+    )
     status_reporter.start()
 
     # Metrics

--- a/tests/status_reporter_test.py
+++ b/tests/status_reporter_test.py
@@ -1,0 +1,57 @@
+from forwarder.status_reporter import StatusReporter
+from typing import Optional, Dict
+import json
+
+
+class FakeProducer:
+    """
+    Instead of publishing to Kafka when produce is called, this will store the payload so it can be checked in a test
+    """
+
+    def __init__(self):
+        self.published_payload: Optional[bytes] = None
+
+    def produce(
+        self, topic: str, payload: bytes, timestamp_ms: int, key: Optional[str] = None,
+    ):
+        self.published_payload = payload
+
+    def close(self):
+        pass
+
+
+def test_when_update_handlers_exist_their_channel_names_are_reported_in_status():
+    test_channel_name_1 = "test_channel_name_1"
+    test_channel_name_2 = "test_channel_name_2"
+
+    # Normally the values in this dictionary are the update handler objects
+    # but the StatusReporter only uses the keys
+    update_handlers = {test_channel_name_1: 1, test_channel_name_2: 2}
+
+    fake_producer = FakeProducer()
+    status_reporter = StatusReporter(update_handlers, fake_producer, "status_topic")  # type: ignore
+    status_reporter.report_status()
+
+    if fake_producer.published_payload is not None:
+        produced_status_message = json.loads(fake_producer.published_payload)
+    # Using set comprehension as order is unimportant
+    assert {
+        stream["channel_name"] for stream in produced_status_message["streams"]
+    } == {
+        test_channel_name_1,
+        test_channel_name_2,
+    }, "Expected channel names for existing update handlers to be reported in the status message"
+
+
+def test_when_no_update_handlers_exist_no_streams_are_present_in_reported_status():
+    update_handlers: Dict = {}
+
+    fake_producer = FakeProducer()
+    status_reporter = StatusReporter(update_handlers, fake_producer, "status_topic")  # type: ignore
+    status_reporter.report_status()
+
+    if fake_producer.published_payload is not None:
+        produced_status_message = json.loads(fake_producer.published_payload)
+    assert (
+        len(produced_status_message["streams"]) == 0
+    ), "Expected no streams in reported status message as there are no update handlers"


### PR DESCRIPTION
I started adding unit tests for StatusReporter in preparation for producing flatbuffer status messages, but we won't be able to merge that until the File Writer and NICOS are ready so we may as well merge unit tests for the existing implementation now.