### PR TITLE
FlatBuffer status messages

### DIFF
--- a/forwarder/status_reporter.py
+++ b/forwarder/status_reporter.py
@@ -47,7 +47,9 @@ class StatusReporter:
             self._interval_ms,
             status_json,
         )
-        self._producer.produce(self._topic, status_message, int(time.time() * 1000))
+        self._producer.produce(
+            self._topic, bytes(status_message), int(time.time() * 1000)
+        )
 
     def stop(self):
         self._producer.close()

--- a/forwarder/status_reporter.py
+++ b/forwarder/status_reporter.py
@@ -11,6 +11,7 @@ class StatusReporter:
         update_handlers: Dict,
         producer: KafkaProducer,
         topic: str,
+        service_id: str,
         interval_ms: int = 4000,
     ):
         self._repeating_timer = RepeatTimer(
@@ -19,6 +20,7 @@ class StatusReporter:
         self._producer = producer
         self._topic = topic
         self._update_handlers = update_handlers
+        self._service_id = service_id
 
     def start(self):
         self._repeating_timer.start()

--- a/forwarder/status_reporter.py
+++ b/forwarder/status_reporter.py
@@ -1,5 +1,5 @@
-from forwarder.kafka.kafka_helpers import create_producer
 from forwarder.repeat_timer import RepeatTimer, milliseconds_to_seconds
+from forwarder.kafka.kafka_producer import KafkaProducer
 from typing import Dict
 import json
 import time
@@ -7,12 +7,16 @@ import time
 
 class StatusReporter:
     def __init__(
-        self, update_handlers: Dict, broker: str, topic: str, interval_ms: int = 4000
+        self,
+        update_handlers: Dict,
+        producer: KafkaProducer,
+        topic: str,
+        interval_ms: int = 4000,
     ):
         self._repeating_timer = RepeatTimer(
             milliseconds_to_seconds(interval_ms), self.report_status
         )
-        self._producer = create_producer(broker)
+        self._producer = producer
         self._topic = topic
         self._update_handlers = update_handlers
 

--- a/forwarder_launch.py
+++ b/forwarder_launch.py
@@ -158,7 +158,9 @@ if __name__ == "__main__":
     consumer.subscribe([config_topic])
 
     status_broker, status_topic = get_broker_and_topic_from_uri(args.status_topic)
-    status_reporter = StatusReporter(update_handlers, status_broker, status_topic)
+    status_reporter = StatusReporter(
+        update_handlers, create_producer(status_broker), status_topic
+    )
     status_reporter.start()
 
     # Metrics

--- a/forwarder_launch.py
+++ b/forwarder_launch.py
@@ -2,6 +2,8 @@ from caproto.threading.client import Context as CaContext
 from p4p.client.thread import Context as PvaContext
 import logging
 import configargparse
+from os import getpid
+from socket import gethostname
 from typing import Optional, Dict
 
 from forwarder.kafka.kafka_helpers import (
@@ -110,6 +112,14 @@ def parse_args():
         type=int,
     )
     parser.add_argument(
+        "--service-id",
+        required=False,
+        help='Identifier for this particular instance of the Forwarder, defaults to "Forwarder.<HOSTNAME>.<PID>',
+        default=f"Forwarder.{gethostname()}.{getpid()}",
+        env_var="SERVICE_ID",
+        type=str,
+    )
+    parser.add_argument(
         "--fake-pv-period",
         required=False,
         help="Set period for random generated PV updates when channel_provider_type is specified as 'fake' (units=milliseconds)",
@@ -159,7 +169,7 @@ if __name__ == "__main__":
 
     status_broker, status_topic = get_broker_and_topic_from_uri(args.status_topic)
     status_reporter = StatusReporter(
-        update_handlers, create_producer(status_broker), status_topic
+        update_handlers, create_producer(status_broker), status_topic, args.service_id
     )
     status_reporter.start()
 

--- a/system_tests/test_forwarding.py
+++ b/system_tests/test_forwarding.py
@@ -26,6 +26,7 @@ import numpy as np
 from .helpers.f142_logdata.AlarmSeverity import AlarmSeverity
 from .helpers.f142_logdata.AlarmStatus import AlarmStatus
 import pytest
+from streaming_data_types.status_x5f2 import deserialise_x5f2
 
 CONFIG_TOPIC = "TEST_forwarderConfig"
 INITIAL_FLOATARRAY_VALUE = (1.1, 2.2, 3.3)
@@ -208,7 +209,8 @@ def test_forwarder_status_shows_added_pvs(docker_compose_forwarding):
 
     status_msg, _ = poll_for_valid_message(cons, expected_file_identifier=None)
 
-    status_json = json.loads(status_msg)
+    status_msg = deserialise_x5f2(status_msg)
+    status_json = json.loads(status_msg.status_json)
     names_of_channels_being_forwarded = {
         stream["channel_name"] for stream in status_json["streams"]
     }
@@ -247,7 +249,9 @@ def test_forwarder_can_handle_rapid_config_updates(docker_compose_forwarding):
     # Get the last available status message
     status_msg = get_last_available_status_message(cons, status_topic)
 
-    streams_json = json.loads(status_msg)["streams"]
+    status_msg = deserialise_x5f2(status_msg)
+    status_json = json.loads(status_msg.status_json)
+    streams_json = status_json["streams"]
     streams = []
     for item in streams_json:
         streams.append(item["channel_name"])

--- a/tests/status_reporter_test.py
+++ b/tests/status_reporter_test.py
@@ -1,6 +1,7 @@
 from forwarder.status_reporter import StatusReporter
 from typing import Optional, Dict
 import json
+from streaming_data_types.status_x5f2 import deserialise_x5f2
 
 
 class FakeProducer:
@@ -33,7 +34,8 @@ def test_when_update_handlers_exist_their_channel_names_are_reported_in_status()
     status_reporter.report_status()
 
     if fake_producer.published_payload is not None:
-        produced_status_message = json.loads(fake_producer.published_payload)
+        deserialised_payload = deserialise_x5f2(fake_producer.published_payload)
+        produced_status_message = json.loads(deserialised_payload.status_json)
     # Using set comprehension as order is unimportant
     assert {
         stream["channel_name"] for stream in produced_status_message["streams"]
@@ -51,7 +53,21 @@ def test_when_no_update_handlers_exist_no_streams_are_present_in_reported_status
     status_reporter.report_status()
 
     if fake_producer.published_payload is not None:
-        produced_status_message = json.loads(fake_producer.published_payload)
+        deserialised_payload = deserialise_x5f2(fake_producer.published_payload)
+        produced_status_message = json.loads(deserialised_payload.status_json)
     assert (
         len(produced_status_message["streams"]) == 0
     ), "Expected no streams in reported status message as there are no update handlers"
+
+
+def test_status_message_contains_service_id():
+    service_id = "test_service_id"
+    update_handlers: Dict = {}
+
+    fake_producer = FakeProducer()
+    status_reporter = StatusReporter(update_handlers, fake_producer, "status_topic", service_id)  # type: ignore
+    status_reporter.report_status()
+
+    if fake_producer.published_payload is not None:
+        deserialised_payload = deserialise_x5f2(fake_producer.published_payload)
+    assert deserialised_payload.service_id == service_id

--- a/tests/status_reporter_test.py
+++ b/tests/status_reporter_test.py
@@ -1,0 +1,57 @@
+from forwarder.status_reporter import StatusReporter
+from typing import Optional, Dict
+import json
+
+
+class FakeProducer:
+    """
+    Instead of publishing to Kafka when produce is called, this will store the payload so it can be checked in a test
+    """
+
+    def __init__(self):
+        self.published_payload: Optional[bytes] = None
+
+    def produce(
+        self, topic: str, payload: bytes, timestamp_ms: int, key: Optional[str] = None,
+    ):
+        self.published_payload = payload
+
+    def close(self):
+        pass
+
+
+def test_when_update_handlers_exist_their_channel_names_are_reported_in_status():
+    test_channel_name_1 = "test_channel_name_1"
+    test_channel_name_2 = "test_channel_name_2"
+
+    # Normally the values in this dictionary are the update handler objects
+    # but the StatusReporter only uses the keys
+    update_handlers = {test_channel_name_1: 1, test_channel_name_2: 2}
+
+    fake_producer = FakeProducer()
+    status_reporter = StatusReporter(update_handlers, fake_producer, "status_topic")  # type: ignore
+    status_reporter.report_status()
+
+    if fake_producer.published_payload is not None:
+        produced_status_message = json.loads(fake_producer.published_payload)
+    # Using set comprehension as order is unimportant
+    assert {
+        stream["channel_name"] for stream in produced_status_message["streams"]
+    } == {
+        test_channel_name_1,
+        test_channel_name_2,
+    }, "Expected channel names for existing update handlers to be reported in the status message"
+
+
+def test_when_no_update_handlers_exist_no_streams_are_present_in_reported_status():
+    update_handlers: Dict = {}
+
+    fake_producer = FakeProducer()
+    status_reporter = StatusReporter(update_handlers, fake_producer, "status_topic")  # type: ignore
+    status_reporter.report_status()
+
+    if fake_producer.published_payload is not None:
+        produced_status_message = json.loads(fake_producer.published_payload)
+    assert (
+        len(produced_status_message["streams"]) == 0
+    ), "Expected no streams in reported status message as there are no update handlers"

--- a/tests/status_reporter_test.py
+++ b/tests/status_reporter_test.py
@@ -29,7 +29,7 @@ def test_when_update_handlers_exist_their_channel_names_are_reported_in_status()
     update_handlers = {test_channel_name_1: 1, test_channel_name_2: 2}
 
     fake_producer = FakeProducer()
-    status_reporter = StatusReporter(update_handlers, fake_producer, "status_topic")  # type: ignore
+    status_reporter = StatusReporter(update_handlers, fake_producer, "status_topic", "")  # type: ignore
     status_reporter.report_status()
 
     if fake_producer.published_payload is not None:
@@ -47,7 +47,7 @@ def test_when_no_update_handlers_exist_no_streams_are_present_in_reported_status
     update_handlers: Dict = {}
 
     fake_producer = FakeProducer()
-    status_reporter = StatusReporter(update_handlers, fake_producer, "status_topic")  # type: ignore
+    status_reporter = StatusReporter(update_handlers, fake_producer, "status_topic", "")  # type: ignore
     status_reporter.report_status()
 
     if fake_producer.published_payload is not None:


### PR DESCRIPTION
Closes #25 
Part of DM-1896

Produces FlatBuffer serialised status messages instead of just utf-8 encoded JSON.
`StatusReporter` unit tests are updated.