### PR TITLE
Make explicitly setting output broker required

### DIFF
--- a/forwarder_launch.py
+++ b/forwarder_launch.py
@@ -78,10 +78,9 @@ def parse_args():
     )
     parser.add_argument(
         "--output-broker",
-        required=False,
+        required=True,
         help="<host[:port]> Kafka broker to forward data into",
         type=str,
-        default="localhost:9092",
         env_var="OUTPUT_BROKER",
     )
     parser.add_argument(

--- a/system_tests/config-files/forwarder_config_fake_epics.ini
+++ b/system_tests/config-files/forwarder_config_fake_epics.ini
@@ -3,3 +3,4 @@ config-topic=localhost:9092/TEST_forwarderConfig
 fake-pv-period=1000
 log-file=/forwarder_logs/forwarder_tests_fake_epics.log
 verbosity=Trace
+output-broker=localhost:9092

--- a/system_tests/config-files/forwarder_config_forwarding.ini
+++ b/system_tests/config-files/forwarder_config_forwarding.ini
@@ -2,3 +2,4 @@ status-topic=localhost:9092/TEST_forwarderStatus
 config-topic=localhost:9092/TEST_forwarderConfig
 log-file=/forwarder_logs/forwarder_tests_forwarding.log
 verbosity=Trace
+output-broker=localhost:9092

--- a/system_tests/config-files/forwarder_config_idle_updates.ini
+++ b/system_tests/config-files/forwarder_config_idle_updates.ini
@@ -3,3 +3,4 @@ config-topic=localhost:9092/TEST_forwarderConfig
 pv-update-period = 1000
 log-file=/forwarder_logs/forwarder_tests_idle_updates.log
 verbosity=Trace
+output-broker=localhost:9092

--- a/system_tests/config-files/forwarder_config_lr.ini
+++ b/system_tests/config-files/forwarder_config_lr.ini
@@ -2,3 +2,4 @@ config-topic=localhost:9092/TEST_forwarderConfig
 status-topic=localhost:9092/TEST_forwarderStatusLR
 log-file=/forwarder_logs/forwarder_tests_lr.log
 verbosity=Trace
+output-broker=localhost:9092


### PR DESCRIPTION
Closes #27 

Now must provide `--output-broker` explicitly; it has no default.
System test run configs updated accordingly.