### PR TITLE
Require latest version of caproto so subscribe does not block if PV not currently available

### DIFF
--- a/forwarder/update_handlers/ca_update_handler.py
+++ b/forwarder/update_handlers/ca_update_handler.py
@@ -38,9 +38,6 @@ class CAUpdateHandler:
         self._producer = producer
         self._output_topic = output_topic
         (self._pv,) = context.get_pvs(pv_name)
-        # Prevent our monitor timing out if PV is not available right now
-        # This causes subscribe() to block so commenting out for now, see ticket #10.
-        # self._pv.timeout = None
         # Subscribe with "data_type='time'" to get timestamp and alarm fields
         sub = self._pv.subscribe(data_type="time")
         sub.add_callback(self._monitor_callback)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 wheel
-caproto >= 0.5.0
+caproto >= 0.5.2
 p4p >= 3.5.0
 confluent_kafka
 flatbuffers == 1.11


### PR DESCRIPTION
and removed comment in the code about the old behaviour.

Closes #2 