### PR TITLE
DM-1138: Store and retrieve last configuration - proof of concept

### DIFF
--- a/forwarder/configuration_store.py
+++ b/forwarder/configuration_store.py
@@ -1,0 +1,47 @@
+import json
+import time
+from typing import Dict
+from confluent_kafka import TopicPartition
+
+from forwarder.parse_config_update import Channel, EpicsProtocol
+from forwarder.update_handlers.ca_update_handler import CAUpdateHandler
+
+
+class ConfigurationStore:
+    def __init__(self, producer, consumer, topic):
+        self._producer = producer
+        self._consumer = consumer
+        self._topic = topic
+
+    def save_configuration(self, update_handlers: Dict):
+        streams = []
+        for name, update_handler in update_handlers.items():
+            channel = {
+                "channel": name,
+                "converter": {
+                    "topic": update_handler.output_topic,
+                    "schema": update_handler.schema,
+                },
+            }
+
+            if isinstance(update_handler, CAUpdateHandler):
+                channel["channel_provider_type"] = "ca"
+
+            streams.append(channel)
+        message = json.dumps(streams).encode("utf-8")
+        self._producer.produce(self._topic, message, int(time.time() * 1000))
+
+    def retrieve_configuration(self):
+        # Retrieve last message
+        topic = TopicPartition(self._topic, 0)
+        _, high_offset = self._consumer.get_watermark_offsets(topic)
+        topic.offset = high_offset - 1
+        self._consumer.assign([topic])
+
+        msg = self._consumer.consume(timeout=2)
+
+        if msg:
+            config_msg = {"cmd": "add", "streams": json.loads(msg[~0].value())}
+            return json.dumps(config_msg).encode("utf-8")
+        else:
+            raise RuntimeError("Could not retrieve stored configuration")

--- a/forwarder/configuration_store.py
+++ b/forwarder/configuration_store.py
@@ -64,15 +64,3 @@ class ConfigurationStore:
 
 
 NullConfigurationStore = mock.create_autospec(ConfigurationStore)
-# class NullConfigurationStore(ConfigurationStore):
-#     def __init__(self):
-#         super().__init__(None, None, "")
-
-#     def save_configuration(self, update_handlers: Dict):
-#         pass
-
-#     def retrieve_configuration(self):
-#         pass
-
-#     def stop(self):
-#         pass

--- a/forwarder/configuration_store.py
+++ b/forwarder/configuration_store.py
@@ -48,3 +48,17 @@ class ConfigurationStore:
     def stop(self):
         self._producer.close()
         self._consumer.close()
+
+
+class NullConfigurationStore(ConfigurationStore):
+    def __init__(self):
+        super().__init__(None, None, "")
+
+    def save_configuration(self, update_handlers: Dict):
+        pass
+
+    def retrieve_configuration(self):
+        pass
+
+    def stop(self):
+        pass

--- a/forwarder/configuration_store.py
+++ b/forwarder/configuration_store.py
@@ -3,7 +3,6 @@ import time
 from typing import Dict
 from confluent_kafka import TopicPartition
 
-from forwarder.parse_config_update import Channel, EpicsProtocol
 from forwarder.update_handlers.ca_update_handler import CAUpdateHandler
 
 

--- a/forwarder/configuration_store.py
+++ b/forwarder/configuration_store.py
@@ -44,3 +44,7 @@ class ConfigurationStore:
             return json.dumps(config_msg).encode("utf-8")
         else:
             raise RuntimeError("Could not retrieve stored configuration")
+
+    def stop(self):
+        self._producer.close()
+        self._consumer.close()

--- a/forwarder/configuration_store.py
+++ b/forwarder/configuration_store.py
@@ -1,6 +1,7 @@
 import json
 import time
 from typing import Dict
+from unittest import mock
 from confluent_kafka import TopicPartition
 
 from forwarder.update_handlers.ca_update_handler import CAUpdateHandler
@@ -50,15 +51,16 @@ class ConfigurationStore:
         self._consumer.close()
 
 
-class NullConfigurationStore(ConfigurationStore):
-    def __init__(self):
-        super().__init__(None, None, "")
+NullConfigurationStore = mock.create_autospec(ConfigurationStore)
+# class NullConfigurationStore(ConfigurationStore):
+#     def __init__(self):
+#         super().__init__(None, None, "")
 
-    def save_configuration(self, update_handlers: Dict):
-        pass
+#     def save_configuration(self, update_handlers: Dict):
+#         pass
 
-    def retrieve_configuration(self):
-        pass
+#     def retrieve_configuration(self):
+#         pass
 
-    def stop(self):
-        pass
+#     def stop(self):
+#         pass

--- a/forwarder/kafka/kafka_helpers.py
+++ b/forwarder/kafka/kafka_helpers.py
@@ -30,13 +30,12 @@ def create_consumer(broker_address: str) -> Consumer:
 def get_broker_and_topic_from_uri(
     uri: str, broker_required: bool = True
 ) -> Tuple[str, str]:
-    if broker_required and "/" not in uri:
+    topic = uri.split("/")[-1]
+    broker = "".join(uri.split("/")[:-1]) if broker_required else ""
+    if broker_required and broker.strip() == "" in uri:
         raise RuntimeError(
             f"Unable to parse URI {uri}, should be of form localhost:9092/topic"
         )
-    topic = uri.split("/")[-1]
-    broker = "".join(uri.split("/")[:-1])
-    broker = broker.strip("/") if broker_required else None
     return broker, topic
 
 

--- a/forwarder/kafka/kafka_helpers.py
+++ b/forwarder/kafka/kafka_helpers.py
@@ -30,13 +30,15 @@ def create_consumer(broker_address: str) -> Consumer:
 def get_broker_and_topic_from_uri(
     uri: str, broker_required: bool = True
 ) -> Tuple[str, str]:
-    topic = uri.split("/")[-1]
-    broker = "".join(uri.split("/")[:-1]) if broker_required else ""
-    if broker_required and broker.strip() == "" in uri:
+    parts = uri.strip().split("/")
+    if len(parts) == 2 and "" not in parts:
+        return parts[0], parts[1]
+    elif broker_required or len(parts) != 1:
         raise RuntimeError(
             f"Unable to parse URI {uri}, should be of form localhost:9092/topic"
         )
-    return broker, topic
+    else:
+        return "", parts[0]
 
 
 def _nanoseconds_to_milliseconds(time_ns: int) -> int:

--- a/forwarder/kafka/kafka_helpers.py
+++ b/forwarder/kafka/kafka_helpers.py
@@ -27,7 +27,6 @@ def create_consumer(broker_address: str) -> Consumer:
     )
 
 
-# TODO: Tests
 def get_broker_and_topic_from_uri(
     uri: str, broker_required: bool = True
 ) -> Tuple[str, str]:
@@ -37,7 +36,7 @@ def get_broker_and_topic_from_uri(
         )
     topic = uri.split("/")[-1]
     broker = "".join(uri.split("/")[:-1])
-    broker = broker.strip("/")
+    broker = broker.strip("/") if broker_required else None
     return broker, topic
 
 

--- a/forwarder/kafka/kafka_helpers.py
+++ b/forwarder/kafka/kafka_helpers.py
@@ -30,7 +30,7 @@ def create_consumer(broker_address: str) -> Consumer:
 def get_broker_and_topic_from_uri(
     uri: str, broker_required: bool = True
 ) -> Tuple[str, str]:
-    parts = uri.strip().split("/")
+    parts = uri.strip().strip("/").split("/")
     if len(parts) == 2 and "" not in parts:
         return parts[0], parts[1]
     elif broker_required or len(parts) != 1:

--- a/forwarder/kafka/kafka_helpers.py
+++ b/forwarder/kafka/kafka_helpers.py
@@ -27,8 +27,11 @@ def create_consumer(broker_address: str) -> Consumer:
     )
 
 
-def get_broker_and_topic_from_uri(uri: str) -> Tuple[str, str]:
-    if "/" not in uri:
+# TODO: Tests
+def get_broker_and_topic_from_uri(
+    uri: str, broker_required: bool = True
+) -> Tuple[str, str]:
+    if broker_required and "/" not in uri:
         raise RuntimeError(
             f"Unable to parse URI {uri}, should be of form localhost:9092/topic"
         )
@@ -63,7 +66,7 @@ def publish_f142_message(
     """
     if alarm_status is None:
         f142_message = serialise_f142(
-            value=data, source_name=source_name, timestamp_unix_ns=timestamp_ns,
+            value=data, source_name=source_name, timestamp_unix_ns=timestamp_ns
         )
     else:
         f142_message = serialise_f142(

--- a/forwarder/kafka/kafka_producer.py
+++ b/forwarder/kafka/kafka_producer.py
@@ -23,7 +23,7 @@ class KafkaProducer:
         self._producer.flush(max_wait_to_publish_producer_queue)
 
     def produce(
-        self, topic: str, payload: bytes, timestamp_ms: int, key: Optional[str] = None,
+        self, topic: str, payload: bytes, timestamp_ms: int, key: Optional[str] = None
     ):
         def ack(err, _):
             if err:

--- a/forwarder/parse_config_update.py
+++ b/forwarder/parse_config_update.py
@@ -96,8 +96,8 @@ def _parse_streams(
             protocol = EpicsProtocol.PVA
 
         try:
-            output_broker, output_topic = get_broker_and_topic_from_uri(
-                update_stream["converter"]["topic"]
+            _, output_topic = get_broker_and_topic_from_uri(
+                update_stream["converter"]["topic"], broker_required=False
             )
         except ValueError:
             logger.warning(

--- a/forwarder/update_handlers/ca_update_handler.py
+++ b/forwarder/update_handlers/ca_update_handler.py
@@ -49,6 +49,7 @@ class CAUpdateHandler:
 
         try:
             self._message_publisher = schema_publishers[schema]
+            self._schema = schema
         except KeyError:
             raise ValueError(
                 f"{schema} is not a recognised supported schema, use one of {list(schema_publishers.keys())}"
@@ -59,6 +60,14 @@ class CAUpdateHandler:
                 milliseconds_to_seconds(periodic_update_ms), self.publish_cached_update
             )
             self._repeating_timer.start()
+
+    @property
+    def output_topic(self):
+        return self._output_topic
+
+    @property
+    def schema(self):
+        return self._schema
 
     def _monitor_callback(self, sub, response: ReadNotifyResponse):
         if self._output_type is None:

--- a/forwarder/update_handlers/fake_update_handler.py
+++ b/forwarder/update_handlers/fake_update_handler.py
@@ -37,6 +37,14 @@ class FakeUpdateHandler:
         )
         self._repeating_timer.start()
 
+    @property
+    def output_topic(self):
+        return self._output_topic
+
+    @property
+    def schema(self):
+        return self._schema
+
     def _timer_callback(self):
         if self._schema == "tdct":
             # tdct needs a 1D array as data to send
@@ -45,7 +53,7 @@ class FakeUpdateHandler:
             # Otherwise 0D (scalar) is fine
             data = np.array(randint(0, 100)).astype(np.int32)
         self._message_publisher(
-            self._producer, self._output_topic, data, self._pv_name, time.time_ns(),
+            self._producer, self._output_topic, data, self._pv_name, time.time_ns()
         )
 
     def stop(self):

--- a/forwarder/update_handlers/pva_update_handler.py
+++ b/forwarder/update_handlers/pva_update_handler.py
@@ -55,6 +55,7 @@ class PVAUpdateHandler:
 
         try:
             self._message_publisher = schema_publishers[schema]
+            self._schema = schema
         except KeyError:
             raise ValueError(
                 f"{schema} is not a recognised supported schema, use one of {list(schema_publishers.keys())}"
@@ -65,6 +66,14 @@ class PVAUpdateHandler:
                 milliseconds_to_seconds(periodic_update_ms), self.publish_cached_update
             )
             self._repeating_timer.start()
+
+    @property
+    def output_topic(self):
+        return self._output_topic
+
+    @property
+    def schema(self):
+        return self._schema
 
     def _monitor_callback(self, response: Value):
         timestamp = (

--- a/forwarder_launch.py
+++ b/forwarder_launch.py
@@ -79,9 +79,7 @@ def update_stored_config():
     try:
         configuration_store.save_configuration(update_handlers)
     except Exception as error:
-        logger.warning(
-            f"Could not store configuration: {error}"
-        )
+        logger.warning(f"Could not store configuration: {error}")
 
 
 def parse_args():
@@ -113,7 +111,7 @@ def parse_args():
         "--storage-topic",
         required=False,
         help="<host[:port][/topic]> Kafka broker/topic for storage of the "
-             "last known forwarding details",
+        "last known forwarding details",
         type=str,
         env_var="STORAGE_TOPIC",
     )
@@ -121,7 +119,7 @@ def parse_args():
         "-s",
         "--skip-retrieval",
         action="store_true",
-        help="Ignore the stored configuration on startup"
+        help="Ignore the stored configuration on startup",
     )
     parser.add_argument(
         "--output-broker",

--- a/forwarder_launch.py
+++ b/forwarder_launch.py
@@ -217,8 +217,13 @@ if __name__ == "__main__":
             create_producer(store_broker), create_consumer(store_broker), store_topic
         )
         if not args.skip_retrieval:
-            stored_config = configuration_store.retrieve_configuration()
-            handle_command(stored_config)
+            try:
+                stored_config = configuration_store.retrieve_configuration()
+                handle_command(stored_config)
+            except RuntimeError as error:
+                logger.error(
+                    "Could not retrieve stored configuration in start-up: " f"{error}"
+                )
     else:
         configuration_store = NullConfigurationStore
 

--- a/forwarder_launch.py
+++ b/forwarder_launch.py
@@ -220,7 +220,7 @@ if __name__ == "__main__":
             stored_config = configuration_store.retrieve_configuration()
             handle_command(stored_config)
     else:
-        configuration_store = NullConfigurationStore()
+        configuration_store = NullConfigurationStore
 
     # Metrics
     # use https://github.com/zillow/aiographite ?

--- a/forwarder_launch.py
+++ b/forwarder_launch.py
@@ -72,12 +72,16 @@ def handle_command(command):
                     elif config_change.command_type == CommandType.REMOVE:
                         unsubscribe_from_pv(channel.name)
                 status_reporter.report_status()
-        try:
-            configuration_store.save_configuration(update_handlers)
-        except Exception as error:
-            logger.warning(
-                f"Could not store configuration: {error}"
-            )
+        update_stored_config()
+
+
+def update_stored_config():
+    try:
+        configuration_store.save_configuration(update_handlers)
+    except Exception as error:
+        logger.warning(
+            f"Could not store configuration: {error}"
+        )
 
 
 def parse_args():

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,6 @@ black
 pre-commit
 pytest
 flake8
-mock
 mypy
 
 # For system tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ black
 pre-commit
 pytest
 flake8
+mock
 mypy
 
 # For system tests

--- a/system_tests/compose/docker-compose-kafka.yml
+++ b/system_tests/compose/docker-compose-kafka.yml
@@ -15,7 +15,7 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_MESSAGE_MAX_BYTES: 10000000
       KAFKA_BROKER_ID: 0
-      KAFKA_CREATE_TOPICS: "TEST_forwarderConfig:1:1,TEST_forwarderData_2_partitions:2:1,TEST_forwarderData_ca:1:1,TEST_forwarderData_pva:1:1,TEST_forwarderData_fake:1:1,TEST_forwarderData_change_config:1:1,TEST_forwarderData_connection_status:1:1"
+      KAFKA_CREATE_TOPICS: "TEST_forwarderConfig:1:1,TEST_forwarderData_2_partitions:2:1,TEST_forwarderData_ca:1:1,TEST_forwarderData_pva:1:1,TEST_forwarderData_fake:1:1,TEST_forwarderData_change_config:1:1,TEST_forwarderData_connection_status:1:1,TEST_forwarderStorage:1:1"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 

--- a/system_tests/compose/docker-compose-storage.yml
+++ b/system_tests/compose/docker-compose-storage.yml
@@ -1,0 +1,12 @@
+
+version: '2'
+
+services:
+  forwarder:
+    image: forwarder:latest
+    network_mode: "host"
+    volumes:
+      - ../config-files/forwarder_config_storage.ini:/forwarder_config_storage.ini
+      - ../logs/:/forwarder_logs/
+    environment:
+      CONFIG_FILE: "/forwarder_config_storage.ini"

--- a/system_tests/config-files/forwarder_config_storage.ini
+++ b/system_tests/config-files/forwarder_config_storage.ini
@@ -1,0 +1,5 @@
+status-topic=localhost:9092/TEST_forwarderStatus
+config-topic=localhost:9092/TEST_forwarderConfig
+storage-topic=localhost:9092/TEST_forwarderStorage
+log-file=/forwarder_logs/forwarder_tests_forwarding.log
+verbosity=Trace

--- a/system_tests/conftest.py
+++ b/system_tests/conftest.py
@@ -253,3 +253,20 @@ def docker_compose_lr(request):
     options["--file"] = ["compose/docker-compose-long-running.yml"]
 
     build_and_run(options, request, "forwarder_config_lr.ini", "forwarder_tests.log")
+
+
+@pytest.fixture(scope="module", autouse=False)
+def docker_compose_storage(request):
+    """
+    :type request: _pytest.python.FixtureRequest
+    """
+    print("Started preparing test environment...", flush=True)
+
+    # Options must be given as long form
+    options = common_options
+    options["--project-name"] = "lr"
+    options["--file"] = ["compose/docker-compose-storage.yml"]
+
+    build_and_run(
+        options, request, "forwarder_config_storage.ini", "forwarder_tests.log"
+    )

--- a/system_tests/conftest.py
+++ b/system_tests/conftest.py
@@ -219,7 +219,7 @@ def docker_compose_forwarding(request):
     options["--file"] = ["compose/docker-compose-forwarding.yml"]
 
     build_and_run(
-        options, request, "forwarder_config_forwarding.ini", "forwarder_tests.log",
+        options, request, "forwarder_config_forwarding.ini", "forwarder_tests.log"
     )
 
 
@@ -236,7 +236,7 @@ def docker_compose_idle_updates(request):
     options["--file"] = ["compose/docker-compose-idle-updates.yml"]
 
     build_and_run(
-        options, request, "forwarder_config_idle_updates.ini", "forwarder_tests.log",
+        options, request, "forwarder_config_idle_updates.ini", "forwarder_tests.log"
     )
 
 
@@ -252,6 +252,4 @@ def docker_compose_lr(request):
     options["--project-name"] = "lr"
     options["--file"] = ["compose/docker-compose-long-running.yml"]
 
-    build_and_run(
-        options, request, "forwarder_config_lr.ini", "forwarder_tests.log",
-    )
+    build_and_run(options, request, "forwarder_config_lr.ini", "forwarder_tests.log")

--- a/system_tests/test_configuration_storage.py
+++ b/system_tests/test_configuration_storage.py
@@ -1,0 +1,48 @@
+from .helpers.producerwrapper import ProducerWrapper
+from time import sleep
+from .helpers.kafka_helpers import create_consumer, poll_for_valid_message
+from .helpers.PVs import PVSTR, PVLONG
+import json
+from streaming_data_types.status_x5f2 import deserialise_x5f2
+
+CONFIG_TOPIC = "TEST_forwarderConfig"
+
+
+def test_forwarder_storage_writes_added_pvs(docker_compose_storage):
+    """
+    WHEN A message configures two new PVs to be forwarded
+    THEN storage message lists new PVs
+    """
+    data_topic = "TEST_forwarderData_change_config"
+    storage_topic = "TEST_forwarderStorage"
+    cons = create_consumer()
+    cons.subscribe([storage_topic])
+    sleep(5)
+
+    pvs = [PVSTR, PVLONG]
+    prod = ProducerWrapper("localhost:9092", CONFIG_TOPIC, data_topic)
+    prod.add_config(pvs)
+
+    sleep(5)
+
+    storage_msg, _ = poll_for_valid_message(cons, expected_file_identifier=None)
+
+    storage_msg = deserialise_x5f2(storage_msg)
+    status_json = json.loads(storage_msg.status_json)
+    names_of_channels_being_forwarded = {stream["channel"] for stream in status_json}
+    names_newly_forwarded_pvs = {PVSTR, PVLONG}
+
+    assert (
+        names_newly_forwarded_pvs
+        == names_newly_forwarded_pvs & names_of_channels_being_forwarded
+    ), (
+        f"Expect these channels to be configured as forwarded: {names_newly_forwarded_pvs}, "
+        f"but storage message report only has: {names_of_channels_being_forwarded}"
+    )
+
+    cons.close()
+
+
+def test_forwarder_storage_shows_added_pvs():
+    # TODO:
+    pass

--- a/system_tests/test_forwarding.py
+++ b/system_tests/test_forwarding.py
@@ -187,10 +187,7 @@ def forwarding_string_and_long(consumer: Consumer, producer: ProducerWrapper):
     initial_long_value = 0
     # Wait for forwarder to forward PV update into Kafka
     sleep(5)
-    expected_values = {
-        PVSTR: initial_string_value,
-        PVLONG: initial_long_value,
-    }
+    expected_values = {PVSTR: initial_string_value, PVLONG: initial_long_value}
     first_msg, _ = poll_for_valid_message(consumer)
     second_msg, _ = poll_for_valid_message(consumer)
     messages = [first_msg, second_msg]

--- a/tests/kafka/fake_producer.py
+++ b/tests/kafka/fake_producer.py
@@ -10,7 +10,7 @@ class FakeProducer:
         self.published_payload: Optional[bytes] = None
 
     def produce(
-        self, topic: str, payload: bytes, timestamp_ms: int, key: Optional[str] = None,
+        self, topic: str, payload: bytes, timestamp_ms: int, key: Optional[str] = None
     ):
         self.published_payload = payload
 

--- a/tests/parsing_kafka_uri_test.py
+++ b/tests/parsing_kafka_uri_test.py
@@ -38,3 +38,12 @@ def test_no_broker_returns_topic_only_when_not_strict():
 
     assert broker == ""
     assert topic == "some_topic"
+
+
+def test_double_slash_before_broker_is_okay():
+    uri = "//localhost:9092/some_topic"
+
+    broker, topic = get_broker_and_topic_from_uri(uri, broker_required=True)
+
+    assert broker == "localhost:9092"
+    assert topic == "some_topic"

--- a/tests/parsing_kafka_uri_test.py
+++ b/tests/parsing_kafka_uri_test.py
@@ -24,4 +24,3 @@ def test_no_broker_returns_topic_only_when_not_strict():
 
     assert broker is None
     assert topic == "some_topic"
-

--- a/tests/parsing_kafka_uri_test.py
+++ b/tests/parsing_kafka_uri_test.py
@@ -1,0 +1,27 @@
+import pytest
+from forwarder.kafka.kafka_helpers import get_broker_and_topic_from_uri
+
+
+def test_broker_and_topic_parsed():
+    uri = "localhost:9092/some_topic"
+    broker, topic = get_broker_and_topic_from_uri(uri)
+
+    assert broker == "localhost:9092"
+    assert topic == "some_topic"
+
+
+def test_no_broker_throws_when_strict():
+    uri = "some_topic"
+
+    with pytest.raises(RuntimeError):
+        get_broker_and_topic_from_uri(uri, broker_required=True)
+
+
+def test_no_broker_returns_topic_only_when_not_strict():
+    uri = "some_topic"
+
+    broker, topic = get_broker_and_topic_from_uri(uri, broker_required=False)
+
+    assert broker is None
+    assert topic == "some_topic"
+

--- a/tests/parsing_kafka_uri_test.py
+++ b/tests/parsing_kafka_uri_test.py
@@ -17,8 +17,15 @@ def test_no_broker_throws_when_strict():
         get_broker_and_topic_from_uri(uri, broker_required=True)
 
 
-def test_no_broker_but_slash_throws_when_strict():
-    uri = "   /some_topic"
+def test_no_broker_but_leading_slash_throws_when_strict():
+    uri = "/some_topic"
+
+    with pytest.raises(RuntimeError):
+        get_broker_and_topic_from_uri(uri, broker_required=True)
+
+
+def test_no_topic_but_trailing_slash_throws_when_strict():
+    uri = "some_host:9092/"
 
     with pytest.raises(RuntimeError):
         get_broker_and_topic_from_uri(uri, broker_required=True)

--- a/tests/parsing_kafka_uri_test.py
+++ b/tests/parsing_kafka_uri_test.py
@@ -17,10 +17,17 @@ def test_no_broker_throws_when_strict():
         get_broker_and_topic_from_uri(uri, broker_required=True)
 
 
+def test_no_broker_but_slash_throws_when_strict():
+    uri = "   /some_topic"
+
+    with pytest.raises(RuntimeError):
+        get_broker_and_topic_from_uri(uri, broker_required=True)
+
+
 def test_no_broker_returns_topic_only_when_not_strict():
     uri = "some_topic"
 
     broker, topic = get_broker_and_topic_from_uri(uri, broker_required=False)
 
-    assert broker is None
+    assert broker == ""
     assert topic == "some_topic"

--- a/tests/save_configuration_test.py
+++ b/tests/save_configuration_test.py
@@ -14,16 +14,12 @@ CHANNELS_TO_STORE = {
 
 EMPTY_STORED_MESSAGE = b"[]"
 
-STORED_MESSAGE = json.dumps([
-    {
-        "channel": "channel1",
-        "converter": {"topic": "topic1", "schema": "f142"},
-    },
-    {
-        "channel": "channel2",
-        "converter": {"topic": "topic2", "schema": "tdct"},
-    },
-]).encode()
+STORED_MESSAGE = json.dumps(
+    [
+        {"channel": "channel1", "converter": {"topic": "topic1", "schema": "f142"}},
+        {"channel": "channel2", "converter": {"topic": "topic2", "schema": "tdct"}},
+    ]
+).encode()
 
 
 class FakeKafkaMessage:

--- a/tests/save_configuration_test.py
+++ b/tests/save_configuration_test.py
@@ -1,5 +1,5 @@
 import json
-import mock
+from unittest import mock
 from confluent_kafka import Consumer
 
 from forwarder.configuration_store import ConfigurationStore

--- a/tests/save_configuration_test.py
+++ b/tests/save_configuration_test.py
@@ -43,7 +43,7 @@ def test_when_multiple_pvs_dumped_config_contains_all_pv_details():
 
     store.save_configuration(CHANNELS_TO_STORE)
 
-    stored_channels = json.loads(producer.published_payload)
+    stored_channels = json.loads(producer.published_payload)  # type: ignore
 
     assert_stored_channel_correct(stored_channels[0])
     assert_stored_channel_correct(stored_channels[1])
@@ -55,7 +55,7 @@ def test_when_no_pvs_stored_info_contains_no_pvs():
 
     store.save_configuration({})
 
-    stored_channels = json.loads(producer.published_payload)
+    stored_channels = json.loads(producer.published_payload)  # type: ignore
 
     assert len(stored_channels) == 0
 

--- a/tests/save_configuration_test.py
+++ b/tests/save_configuration_test.py
@@ -1,0 +1,19 @@
+from forwarder.parse_config_update import Channel, EpicsProtocol
+
+
+CHANNELS = set()
+
+def add_to_configuration(channels):
+    for channel in channels:
+        if channel in CHANNELS:
+
+        CHANNELS
+
+
+def test_on_add_pv_dumped_config_contains_pv_details():
+    channel_to_add = Channel("MY_PV_NAME", EpicsProtocol.PVA, "MY_TOPIC", "f142")
+
+    add_to_configuration((channel_to_add,))
+
+
+    assert new_pv in dumped_config

--- a/tests/save_configuration_test.py
+++ b/tests/save_configuration_test.py
@@ -1,19 +1,94 @@
+import json
+import mock
+from confluent_kafka import Consumer
+
+from forwarder.configuration_store import ConfigurationStore
 from forwarder.parse_config_update import Channel, EpicsProtocol
+from tests.kafka.fake_producer import FakeProducer
 
 
-CHANNELS = set()
+CHANNELS_TO_STORE = {
+    "channel1": Channel("channel1", EpicsProtocol.PVA, "topic1", "f142"),
+    "channel2": Channel("channel2", EpicsProtocol.PVA, "topic2", "tdct"),
+}
 
-def add_to_configuration(channels):
-    for channel in channels:
-        if channel in CHANNELS:
+EMPTY_STORED_MESSAGE = b"[]"
 
-        CHANNELS
+STORED_MESSAGE = json.dumps([
+    {
+        "channel": "channel1",
+        "converter": {"topic": "topic1", "schema": "f142"},
+    },
+    {
+        "channel": "channel2",
+        "converter": {"topic": "topic2", "schema": "tdct"},
+    },
+]).encode()
 
 
-def test_on_add_pv_dumped_config_contains_pv_details():
-    channel_to_add = Channel("MY_PV_NAME", EpicsProtocol.PVA, "MY_TOPIC", "f142")
+class FakeKafkaMessage:
+    def __init__(self, message):
+        self._message = message
 
-    add_to_configuration((channel_to_add,))
+    def value(self):
+        return self._message
 
 
-    assert new_pv in dumped_config
+def assert_stored_channel_correct(outputted_channel):
+    assert outputted_channel["channel"] in CHANNELS_TO_STORE
+    original = CHANNELS_TO_STORE[outputted_channel["channel"]]
+    assert outputted_channel["converter"]["topic"] == original.output_topic
+    assert outputted_channel["converter"]["schema"] == original.schema
+
+
+def test_when_multiple_pvs_dumped_config_contains_all_pv_details():
+    producer = FakeProducer()
+    store = ConfigurationStore(producer, consumer=None, topic="store_topic")
+
+    store.save_configuration(CHANNELS_TO_STORE)
+
+    stored_channels = json.loads(producer.published_payload)
+
+    assert_stored_channel_correct(stored_channels[0])
+    assert_stored_channel_correct(stored_channels[1])
+
+
+def test_when_no_pvs_stored_info_contains_no_pvs():
+    producer = FakeProducer()
+    store = ConfigurationStore(producer, consumer=None, topic="store_topic")
+
+    store.save_configuration({})
+
+    stored_channels = json.loads(producer.published_payload)
+
+    assert len(stored_channels) == 0
+
+
+def test_retrieving_stored_info_with_no_pvs_gets_empty_streams():
+    mock_consumer = mock.create_autospec(Consumer)
+    mock_consumer.get_watermark_offsets.return_value = (0, 100)
+    mock_consumer.consume.return_value = [FakeKafkaMessage(EMPTY_STORED_MESSAGE)]
+    store = ConfigurationStore(
+        producer=None, consumer=mock_consumer, topic="store_topic"
+    )
+
+    config_as_json = store.retrieve_configuration()
+    config = json.loads(config_as_json)
+
+    assert len(config["streams"]) == 0
+
+
+def test_retrieving_stored_info_with_multiple_pvs_gets_streams():
+    mock_consumer = mock.create_autospec(Consumer)
+    mock_consumer.get_watermark_offsets.return_value = (0, 100)
+    mock_consumer.consume.return_value = [FakeKafkaMessage(STORED_MESSAGE)]
+    store = ConfigurationStore(
+        producer=None, consumer=mock_consumer, topic="store_topic"
+    )
+
+    config_as_json = store.retrieve_configuration()
+    config = json.loads(config_as_json)
+
+    assert len(config["streams"]) == 2
+    assert_stored_channel_correct(config["streams"][0])
+    assert_stored_channel_correct(config["streams"][1])

--- a/tests/status_reporter_test.py
+++ b/tests/status_reporter_test.py
@@ -13,7 +13,9 @@ def test_when_update_handlers_exist_their_channel_names_are_reported_in_status()
     update_handlers = {test_channel_name_1: 1, test_channel_name_2: 2}
 
     fake_producer = FakeProducer()
-    status_reporter = StatusReporter(update_handlers, fake_producer, "status_topic")  # type: ignore
+    status_reporter = StatusReporter(
+        update_handlers, fake_producer, "status_topic"
+    )  # type: ignore
     status_reporter.report_status()
 
     if fake_producer.published_payload is not None:
@@ -31,7 +33,9 @@ def test_when_no_update_handlers_exist_no_streams_are_present_in_reported_status
     update_handlers: Dict = {}
 
     fake_producer = FakeProducer()
-    status_reporter = StatusReporter(update_handlers, fake_producer, "status_topic")  # type: ignore
+    status_reporter = StatusReporter(
+        update_handlers, fake_producer, "status_topic"
+    )  # type: ignore
     status_reporter.report_status()
 
     if fake_producer.published_payload is not None:

--- a/tests/status_reporter_test.py
+++ b/tests/status_reporter_test.py
@@ -14,8 +14,8 @@ def test_when_update_handlers_exist_their_channel_names_are_reported_in_status()
 
     fake_producer = FakeProducer()
     status_reporter = StatusReporter(
-        update_handlers, fake_producer, "status_topic"
-    )  # type: ignore
+        update_handlers, fake_producer, "status_topic"  # type: ignore
+    )
     status_reporter.report_status()
 
     if fake_producer.published_payload is not None:
@@ -34,8 +34,8 @@ def test_when_no_update_handlers_exist_no_streams_are_present_in_reported_status
 
     fake_producer = FakeProducer()
     status_reporter = StatusReporter(
-        update_handlers, fake_producer, "status_topic"
-    )  # type: ignore
+        update_handlers, fake_producer, "status_topic"  # type: ignore
+    )
     status_reporter.report_status()
 
     if fake_producer.published_payload is not None:

--- a/tests/update_handlers/pva_update_handler_test.py
+++ b/tests/update_handlers/pva_update_handler_test.py
@@ -19,8 +19,8 @@ def test_update_handler_publishes_enum_update():
     pv_source_name = "source_name"
 
     pva_update_handler = PVAUpdateHandler(
-        producer, context, pv_source_name, "output_topic", "f142"
-    )  # type: ignore
+        producer, context, pv_source_name, "output_topic", "f142"  # type: ignore
+    )
     context.call_monitor_callback_with_fake_pv_update(
         NTEnum(valueAlarm=True).wrap(
             {"index": pv_index, "choices": [pv_value_str, "choice1", "choice2"]},
@@ -45,8 +45,8 @@ def test_update_handler_publishes_float_update(pv_value, pv_type):
     pv_source_name = "source_name"
 
     pva_update_handler = PVAUpdateHandler(
-        producer, context, pv_source_name, "output_topic", "f142"
-    )  # type: ignore
+        producer, context, pv_source_name, "output_topic", "f142"  # type: ignore
+    )
     context.call_monitor_callback_with_fake_pv_update(
         NTScalar(pv_type, valueAlarm=True).wrap(pv_value, timestamp=pv_timestamp_s)
     )
@@ -71,8 +71,8 @@ def test_update_handler_publishes_int_update(pv_value, pv_type):
     pv_source_name = "source_name"
 
     pva_update_handler = PVAUpdateHandler(
-        producer, context, pv_source_name, "output_topic", "f142"
-    )  # type: ignore
+        producer, context, pv_source_name, "output_topic", "f142"  # type: ignore
+    )
     context.call_monitor_callback_with_fake_pv_update(
         NTScalar(pv_type, valueAlarm=True).wrap(pv_value, timestamp=pv_timestamp_s)
     )
@@ -100,8 +100,8 @@ def test_update_handler_publishes_alarm_update():
     alarm_message = "HIGH_ALARM"
 
     pva_update_handler = PVAUpdateHandler(
-        producer, context, pv_source_name, "output_topic", "f142"
-    )  # type: ignore
+        producer, context, pv_source_name, "output_topic", "f142"  # type: ignore
+    )
     context.call_monitor_callback_with_fake_pv_update(
         NTScalar(pv_type, valueAlarm=True).wrap(
             {

--- a/tests/update_handlers/pva_update_handler_test.py
+++ b/tests/update_handlers/pva_update_handler_test.py
@@ -18,7 +18,9 @@ def test_update_handler_publishes_enum_update():
     pv_timestamp_s = 1.1  # seconds from unix epoch
     pv_source_name = "source_name"
 
-    pva_update_handler = PVAUpdateHandler(producer, context, pv_source_name, "output_topic", "f142")  # type: ignore
+    pva_update_handler = PVAUpdateHandler(
+        producer, context, pv_source_name, "output_topic", "f142"
+    )  # type: ignore
     context.call_monitor_callback_with_fake_pv_update(
         NTEnum(valueAlarm=True).wrap(
             {"index": pv_index, "choices": [pv_value_str, "choice1", "choice2"]},
@@ -42,7 +44,9 @@ def test_update_handler_publishes_float_update(pv_value, pv_type):
     pv_timestamp_s = 1.1  # seconds from unix epoch
     pv_source_name = "source_name"
 
-    pva_update_handler = PVAUpdateHandler(producer, context, pv_source_name, "output_topic", "f142")  # type: ignore
+    pva_update_handler = PVAUpdateHandler(
+        producer, context, pv_source_name, "output_topic", "f142"
+    )  # type: ignore
     context.call_monitor_callback_with_fake_pv_update(
         NTScalar(pv_type, valueAlarm=True).wrap(pv_value, timestamp=pv_timestamp_s)
     )
@@ -66,7 +70,9 @@ def test_update_handler_publishes_int_update(pv_value, pv_type):
     pv_timestamp_s = 1.1  # seconds from unix epoch
     pv_source_name = "source_name"
 
-    pva_update_handler = PVAUpdateHandler(producer, context, pv_source_name, "output_topic", "f142")  # type: ignore
+    pva_update_handler = PVAUpdateHandler(
+        producer, context, pv_source_name, "output_topic", "f142"
+    )  # type: ignore
     context.call_monitor_callback_with_fake_pv_update(
         NTScalar(pv_type, valueAlarm=True).wrap(pv_value, timestamp=pv_timestamp_s)
     )
@@ -87,11 +93,15 @@ def test_update_handler_publishes_alarm_update():
     pv_type = "i"
     pv_timestamp_s = 1.1  # seconds from unix epoch
     pv_source_name = "source_name"
-    alarm_status = 4  # Indicates RECORD alarm, we map the alarm message to a specific alarm status to forward
+    alarm_status = (
+        4
+    )  # Indicates RECORD alarm, we map the alarm message to a specific alarm status to forward
     alarm_severity = 1  # AlarmSeverity.MINOR
     alarm_message = "HIGH_ALARM"
 
-    pva_update_handler = PVAUpdateHandler(producer, context, pv_source_name, "output_topic", "f142")  # type: ignore
+    pva_update_handler = PVAUpdateHandler(
+        producer, context, pv_source_name, "output_topic", "f142"
+    )  # type: ignore
     context.call_monitor_callback_with_fake_pv_update(
         NTScalar(pv_type, valueAlarm=True).wrap(
             {

--- a/tests/update_handlers/pva_update_handler_test.py
+++ b/tests/update_handlers/pva_update_handler_test.py
@@ -93,9 +93,7 @@ def test_update_handler_publishes_alarm_update():
     pv_type = "i"
     pv_timestamp_s = 1.1  # seconds from unix epoch
     pv_source_name = "source_name"
-    alarm_status = (
-        4
-    )  # Indicates RECORD alarm, we map the alarm message to a specific alarm status to forward
+    alarm_status = 4  # Indicates RECORD alarm, we map the alarm message to a specific alarm status to forward
     alarm_severity = 1  # AlarmSeverity.MINOR
     alarm_message = "HIGH_ALARM"
 


### PR DESCRIPTION
On a command message it will store a complete list of everything being forwarded in a Kafka topic (as JSON).

On restart it will retrieve the last set of settings and start them forwarding.

This is all optional (enabled by defining the storage topic) and the retrieval on start-up can be skipped using a flag.

Black and mypy were fighting on my mac, so I'll need to see what Jenkins thinks