### PR TITLE
Test forwarding arrays

### DIFF
--- a/forwarder/update_handlers/pva_update_handler.py
+++ b/forwarder/update_handlers/pva_update_handler.py
@@ -110,7 +110,18 @@ class PVAUpdateHandler:
                 if response.type()["value"].getID() == "enum_t":
                     is_enum = True
             except AttributeError:
-                self._output_type = numpy_type_from_p4p_type[response.type()["value"]]
+                try:
+                    self._output_type = numpy_type_from_p4p_type[
+                        response.type()["value"]
+                    ]
+                except TypeError:
+                    if isinstance(response.value, np.ndarray):
+                        self._output_type = response.value.dtype.type
+                    else:
+                        self._logger.error(
+                            f"Don't know what numpy dtype to use for channel type {type(response)}"
+                        )
+                        return
 
             if is_enum:
                 # We forward enum as string

--- a/forwarder/update_handlers/pva_update_handler.py
+++ b/forwarder/update_handlers/pva_update_handler.py
@@ -110,18 +110,11 @@ class PVAUpdateHandler:
                 if response.type()["value"].getID() == "enum_t":
                     is_enum = True
             except AttributeError:
-                try:
-                    self._output_type = numpy_type_from_p4p_type[
-                        response.type()["value"]
-                    ]
-                except TypeError:
-                    if isinstance(response.value, np.ndarray):
-                        self._output_type = response.value.dtype.type
-                    else:
-                        self._logger.error(
-                            f"Don't know what numpy dtype to use for channel type {type(response)}"
-                        )
-                        return
+                self._output_type = numpy_type_from_p4p_type[
+                    response.type()["value"][
+                        -1
+                    ]  # [-1] so that "a" prefix is dropped from array types
+                ]
 
             if is_enum:
                 # We forward enum as string

--- a/forwarder/update_handlers/pva_update_handler.py
+++ b/forwarder/update_handlers/pva_update_handler.py
@@ -110,10 +110,10 @@ class PVAUpdateHandler:
                 if response.type()["value"].getID() == "enum_t":
                     is_enum = True
             except AttributeError:
+                # Attribute error raised because getID doesn't exist for scalar and scalar-array types.
+                # Array output types are prefixed by "a", we don't need this.
                 self._output_type = numpy_type_from_p4p_type[
-                    response.type()["value"][
-                        -1
-                    ]  # [-1] so that "a" prefix is dropped from array types
+                    response.type()["value"][-1]
                 ]
 
             if is_enum:

--- a/system_tests/compose/docker-compose-kafka.yml
+++ b/system_tests/compose/docker-compose-kafka.yml
@@ -23,7 +23,7 @@ services:
     image: zookeeper:3.4
 
   ioc:
-    image: screamingudder/softioc:cba04c4
+    image: screamingudder/softioc:69433bc
     stdin_open: true
     tty: true
     network_mode: "host"

--- a/tests/update_handlers/pva_update_handler_test.py
+++ b/tests/update_handlers/pva_update_handler_test.py
@@ -1,7 +1,7 @@
 from tests.kafka.fake_producer import FakeProducer
 from tests.test_helpers.p4p_fakes import FakeContext
 from forwarder.update_handlers.pva_update_handler import PVAUpdateHandler
-from p4p.nt import NTScalar, NTEnum, NTNDArray
+from p4p.nt import NTScalar, NTEnum
 from streaming_data_types.logdata_f142 import deserialise_f142
 from cmath import isclose
 import numpy as np
@@ -60,11 +60,14 @@ def test_update_handler_publishes_floatarray_update():
     producer = FakeProducer()
     context = FakeContext()
 
+    pv_timestamp_s = 1.1  # seconds from unix epoch
     pv_source_name = "source_name"
-    pv_value = np.array([1.1, 2.2, 3.3], dtype=np.float)
+    pv_value = np.array([1.1, 2.2, 3.3], dtype=np.float32)
 
     pva_update_handler = PVAUpdateHandler(producer, context, pv_source_name, "output_topic", "f142")  # type: ignore
-    context.call_monitor_callback_with_fake_pv_update(NTNDArray().wrap(pv_value))
+    context.call_monitor_callback_with_fake_pv_update(
+        NTScalar("af", valueAlarm=True).wrap(pv_value, timestamp=pv_timestamp_s)
+    )
 
     assert producer.published_payload is not None
     pv_update_output = deserialise_f142(producer.published_payload)


### PR DESCRIPTION
Closes #34 
(DM-1864 also resolved by updating softioc)

- Adds system test for forwarding arrays.
- Adds unit test and fix for forwarding PVA array updates.
- Set initial values of PVs in a "setup" function during system tests, so that they are independent of initial value set in the softioc.
- softioc container was updated to remove SCAN field from the arrays, which was making it difficult to test.

