### PR TITLE
Fix invalid command causes crash

### DIFF
--- a/forwarder/parse_config_update.py
+++ b/forwarder/parse_config_update.py
@@ -44,7 +44,7 @@ def parse_config_update(config_update_payload: str) -> Optional[ConfigUpdate]:
         logger.warning('Message received in config topic contained no "cmd" field')
         return None
     except json.JSONDecodeError:
-        logger.warning(f'Invalid command received')
+        logger.warning("Command received was not recognised as valid JSON")
     except ValueError:
         logger.warning(f'Unrecognised command "{config["cmd"]}" received')
         return None

--- a/forwarder/parse_config_update.py
+++ b/forwarder/parse_config_update.py
@@ -1,5 +1,4 @@
 import json
-
 from forwarder.application_logger import get_logger
 import attr
 from enum import Enum

--- a/forwarder/parse_config_update.py
+++ b/forwarder/parse_config_update.py
@@ -1,4 +1,5 @@
 import json
+
 from forwarder.application_logger import get_logger
 import attr
 from enum import Enum
@@ -37,12 +38,14 @@ class ConfigUpdate:
 
 
 def parse_config_update(config_update_payload: str) -> Optional[ConfigUpdate]:
-    config = json.loads(config_update_payload)
     try:
+        config = json.loads(config_update_payload)
         command_type = CommandType(config["cmd"])
     except KeyError:
         logger.warning('Message received in config topic contained no "cmd" field')
         return None
+    except json.JSONDecodeError:
+        logger.warning(f'Invalid command received')
     except ValueError:
         logger.warning(f'Unrecognised command "{config["cmd"]}" received')
         return None


### PR DESCRIPTION
This patch prevents that an ill-formatted or an empty command crashes the forwarder.

Closes #7 
