### PR TITLE
Allow removing handlers by name, topic and/or schema

### DIFF
--- a/forwarder/application_logger.py
+++ b/forwarder/application_logger.py
@@ -11,7 +11,7 @@ def setup_logger(
     graylog_logger_address: Optional[str] = None,
 ) -> logging.Logger:
     if log_file_name is not None:
-        logging.basicConfig(filename=log_file_name)
+        logging.basicConfig(filename=log_file_name, format="%(asctime)s %(message)s")
     else:
         logging.basicConfig()
     logger = logging.getLogger(logger_name)

--- a/forwarder/handle_config_change.py
+++ b/forwarder/handle_config_change.py
@@ -26,14 +26,17 @@ def _subscribe_to_pv(
         logger.warning("Forwarder asked to subscribe to PV it is already subscribed to")
         return
 
-    update_handlers[new_channel.name] = create_update_handler(
-        producer,
-        ca_ctx,
-        pva_ctx,
-        new_channel,
-        fake_pv_period,
-        periodic_update_ms=pv_update_period,
-    )
+    try:
+        update_handlers[new_channel.name] = create_update_handler(
+            producer,
+            ca_ctx,
+            pva_ctx,
+            new_channel,
+            fake_pv_period,
+            periodic_update_ms=pv_update_period,
+        )
+    except RuntimeError as error:
+        logger.error(str(error))
     logger.info(f"Subscribed to PV {new_channel.name}")
 
 

--- a/forwarder/handle_config_change.py
+++ b/forwarder/handle_config_change.py
@@ -1,0 +1,92 @@
+from forwarder.update_handlers.create_update_handler import create_update_handler
+from forwarder.parse_config_update import (
+    CommandType,
+    Channel,
+    ConfigUpdate,
+)
+from typing import Optional, Dict
+from logging import Logger
+from forwarder.status_reporter import StatusReporter
+from caproto.threading.client import Context as CaContext
+from p4p.client.thread import Context as PvaContext
+from forwarder.kafka.kafka_producer import KafkaProducer
+
+
+def _subscribe_to_pv(
+    new_channel: Channel,
+    update_handlers: Dict,
+    producer: KafkaProducer,
+    ca_ctx: CaContext,
+    pva_ctx: PvaContext,
+    logger: Logger,
+    fake_pv_period: int,
+    pv_update_period: Optional[int],
+):
+    if new_channel.name in update_handlers.keys():
+        logger.warning("Forwarder asked to subscribe to PV it is already subscribed to")
+        return
+
+    update_handlers[new_channel.name] = create_update_handler(
+        producer,
+        ca_ctx,
+        pva_ctx,
+        new_channel,
+        fake_pv_period,
+        periodic_update_ms=pv_update_period,
+    )
+    logger.info(f"Subscribed to PV {new_channel.name}")
+
+
+def _unsubscribe_from_pv(name: str, update_handlers: Dict, logger: Logger):
+    try:
+        update_handlers[name].stop()
+        del update_handlers[name]
+    except KeyError:
+        logger.warning(
+            "Forwarder asked to unsubscribe from a PV it is not subscribed to"
+        )
+    logger.info(f"Unsubscribed from PV {name}")
+
+
+def _unsubscribe_from_all(update_handlers: Dict, logger: Logger):
+    for _, update_handler in update_handlers.items():
+        update_handler.stop()
+    update_handlers.clear()
+    logger.info("Unsubscribed from all PVs")
+
+
+def handle_configuration_change(
+    configuration_change: ConfigUpdate,
+    fake_pv_period: int,
+    pv_update_period: Optional[int],
+    update_handlers: Dict,
+    producer: KafkaProducer,
+    ca_ctx: CaContext,
+    pva_ctx: PvaContext,
+    logger: Logger,
+    status_reporter: StatusReporter,
+):
+    """
+    Add or remove update handlers according to the requested change in configuration
+    """
+    if configuration_change.command_type == CommandType.REMOVE_ALL:
+        _unsubscribe_from_all(update_handlers, logger)
+    elif configuration_change.command_type == CommandType.MALFORMED:
+        return
+    else:
+        if configuration_change.channels is not None:
+            for channel in configuration_change.channels:
+                if configuration_change.command_type == CommandType.ADD:
+                    _subscribe_to_pv(
+                        channel,
+                        update_handlers,
+                        producer,
+                        ca_ctx,
+                        pva_ctx,
+                        logger,
+                        fake_pv_period,
+                        pv_update_period,
+                    )
+                elif configuration_change.command_type == CommandType.REMOVE:
+                    _unsubscribe_from_pv(channel.name, update_handlers, logger)
+    status_reporter.report_status()

--- a/forwarder/handle_config_change.py
+++ b/forwarder/handle_config_change.py
@@ -44,7 +44,7 @@ def _subscribe_to_pv(
 
 
 def _unsubscribe_from_pv(
-    name: str, update_handlers: Dict[Channel, UpdateHandler], logger: Logger
+    name: Optional[str], update_handlers: Dict[Channel, UpdateHandler], logger: Logger
 ):
     channels_to_remove = []
     for channel in update_handlers.keys():

--- a/forwarder/parse_commandline_args.py
+++ b/forwarder/parse_commandline_args.py
@@ -1,0 +1,141 @@
+import logging
+import configargparse
+from os import getpid
+from socket import gethostname
+import configparser
+
+
+class VersionArgParser(configargparse.ArgumentParser):
+    def error(self, message: str):
+        """
+        Override the default implementation so nothing gets printed to screen
+        """
+        raise RuntimeError("Did not ask for --version")
+
+    def _print_message(self, message: str, file: None = None):
+        """
+        Override the default implementation so nothing gets printed to screen
+        """
+        raise RuntimeError("Did not ask for --version")
+
+
+def get_version() -> str:
+    """
+    Gets the current version from the setup.cfg file
+    """
+    config = configparser.ConfigParser()
+    config.read("setup.cfg")
+    return str(config["metadata"]["version"])
+
+
+def _print_version_if_requested():
+    version_arg_parser = VersionArgParser()
+    version_arg_parser.add_argument(
+        "--version",
+        required=True,
+        action="store_true",
+        help="Print application version and exit",
+        env_var="VERSION",
+    )
+    try:
+        version_arg_parser.parse_args()
+        print(get_version())
+        exit()
+    except RuntimeError:
+        pass
+
+
+def parse_args():
+    _print_version_if_requested()
+
+    parser = configargparse.ArgumentParser(
+        description="Writes NeXus files in a format specified with a json template.\n"
+        "Writer modules can be used to populate the file from Kafka topics."
+    )
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="Print application version and exit",
+        env_var="VERSION",
+    )
+    parser.add_argument(
+        "--config-topic",
+        required=True,
+        help="<host[:port][/topic]> Kafka broker/topic to listen for commands",
+        type=str,
+        env_var="CONFIG_TOPIC",
+    )
+    parser.add_argument(
+        "--status-topic",
+        required=True,
+        help="<host[:port][/topic]> Kafka broker/topic to publish status updates on",
+        type=str,
+        env_var="STATUS_TOPIC",
+    )
+    parser.add_argument(
+        "--output-broker",
+        required=True,
+        help="<host[:port]> Kafka broker to forward data into",
+        type=str,
+        env_var="OUTPUT_BROKER",
+    )
+    parser.add_argument(
+        "--graylog-logger-address",
+        required=False,
+        help="<host:port> Log to Graylog",
+        type=str,
+        env_var="GRAYLOG_LOGGER_ADDRESS",
+    )
+    parser.add_argument(
+        "--log-file", required=False, help="Log filename", type=str, env_var="LOG_FILE"
+    )
+    parser.add_argument(
+        "-c",
+        "--config-file",
+        required=False,
+        is_config_file=True,
+        help="Read configuration from an ini file",
+        env_var="CONFIG_FILE",
+    )
+    parser.add_argument(
+        "--pv-update-period",
+        required=False,
+        help="If set then PV value will be sent with this interval even if unchanged (units=milliseconds)",
+        env_var="PV_UPDATE_PERIOD",
+        type=int,
+    )
+    parser.add_argument(
+        "--service-id",
+        required=False,
+        help='Identifier for this particular instance of the Forwarder, defaults to "Forwarder.<HOSTNAME>.<PID>',
+        default=f"Forwarder.{gethostname()}.{getpid()}",
+        env_var="SERVICE_ID",
+        type=str,
+    )
+    parser.add_argument(
+        "--fake-pv-period",
+        required=False,
+        help="Period for random generated PV updates when channel_provider_type is set to 'fake' (units=milliseconds)",
+        env_var="FAKE_PV_PERIOD",
+        type=int,
+        default=1000,
+    )
+    log_choice_to_enum = {
+        "Trace": logging.DEBUG,
+        "Debug": logging.DEBUG,
+        "Warning": logging.WARNING,
+        "Error": logging.ERROR,
+        "Critical": logging.CRITICAL,
+    }
+    parser.add_argument(
+        "-v",
+        "--verbosity",
+        required=False,
+        help="Set logging level",
+        choices=log_choice_to_enum.keys(),
+        default="Error",
+        env_var="VERBOSITY",
+    )
+    optargs = parser.parse_args()
+    optargs.verbosity = log_choice_to_enum[optargs.verbosity]
+    return optargs

--- a/forwarder/parse_config_update.py
+++ b/forwarder/parse_config_update.py
@@ -32,15 +32,17 @@ class EpicsProtocol(Enum):
     NONE = "none"
 
 
-@attr.s
+# Using frozen=True makes instances of Channel immutable
+# and means attrs generates a __hash__ method so that we can use it as a dictionary key
+@attr.s(frozen=True)
 class Channel:
     name = attr.ib(type=str)
     protocol = attr.ib(type=EpicsProtocol)
-    output_topic = attr.ib(type=str)
-    schema = attr.ib(type=str)
+    output_topic = attr.ib(type=Optional[str])
+    schema = attr.ib(type=Optional[str])
 
 
-@attr.s
+@attr.s(frozen=True)
 class ConfigUpdate:
     command_type = attr.ib(type=CommandType)
     channels = attr.ib(type=Optional[Tuple[Channel, ...]])

--- a/forwarder/parse_config_update.py
+++ b/forwarder/parse_config_update.py
@@ -36,7 +36,7 @@ class EpicsProtocol(Enum):
 # and means attrs generates a __hash__ method so that we can use it as a dictionary key
 @attr.s(frozen=True)
 class Channel:
-    name = attr.ib(type=str)
+    name = attr.ib(type=Optional[str])
     protocol = attr.ib(type=EpicsProtocol)
     output_topic = attr.ib(type=Optional[str])
     schema = attr.ib(type=Optional[str])
@@ -98,24 +98,22 @@ def _parse_streams(
     command_type: CommandType, streams: List[StreamInfo]
 ) -> Generator[Channel, None, None]:
     for stream in streams:
-        if not stream.channel:
+        fields_present = (bool(stream.channel), bool(stream.schema), bool(stream.topic))
+        if command_type == CommandType.ADD and not all(fields_present):
             logger.warning(
-                "Channel name not given when trying to add stream from configuration update message."
+                f"All details must be given when adding a stream, but received ADD request for "
+                f"channel='{stream.channel}', schema='{stream.schema}', topic='{stream.topic}'. Skipping."
             )
             continue
 
-        if command_type == CommandType.REMOVE:
-            yield Channel(stream.channel, EpicsProtocol.NONE, "", "")
-            continue
-
-        if not stream.schema or not stream.topic:
+        if command_type == CommandType.REMOVE and not any(fields_present):
             logger.warning(
-                f"Schema or output topic not given when trying to add stream from configuration "
-                f"update message. Channel was given as {stream.channel}."
+                f"At least one of channel, schema or topic must be given when removing a stream, but received REMOVE "
+                f"request for channel='{stream.channel}', schema='{stream.schema}', topic='{stream.topic}'. Skipping."
             )
             continue
 
-        if stream.schema not in schema_publishers.keys():
+        if stream.schema and stream.schema not in schema_publishers.keys():
             logger.warning(
                 f'Unsupported schema type "{stream.schema}" specified for'
                 f"stream in configuration update message."

--- a/forwarder/status_reporter.py
+++ b/forwarder/status_reporter.py
@@ -6,6 +6,7 @@ import json
 import time
 from socket import gethostname
 from os import getpid
+from logging import Logger
 
 
 class StatusReporter:
@@ -16,6 +17,7 @@ class StatusReporter:
         topic: str,
         service_id: str,
         version: str,
+        logger: Logger,
         interval_ms: int = 4000,
     ):
         self._repeating_timer = RepeatTimer(
@@ -27,6 +29,7 @@ class StatusReporter:
         self._service_id = service_id
         self._interval_ms = interval_ms
         self._version = version
+        self._logger = logger
 
     def start(self):
         self._repeating_timer.start()
@@ -52,6 +55,7 @@ class StatusReporter:
         self._producer.produce(
             self._topic, bytes(status_message), int(time.time() * 1000)
         )
+        self._logger.debug(status_json)
 
     def stop(self):
         self._producer.close()

--- a/forwarder/status_reporter.py
+++ b/forwarder/status_reporter.py
@@ -7,12 +7,14 @@ import time
 from socket import gethostname
 from os import getpid
 from logging import Logger
+from forwarder.update_handlers.create_update_handler import UpdateHandler
+from forwarder.parse_config_update import Channel
 
 
 class StatusReporter:
     def __init__(
         self,
-        update_handlers: Dict,
+        update_handlers: Dict[Channel, UpdateHandler],
         producer: KafkaProducer,
         topic: str,
         service_id: str,
@@ -38,8 +40,8 @@ class StatusReporter:
         status_json = json.dumps(
             {
                 "streams": [
-                    {"channel_name": channel_name}
-                    for channel_name in self._update_handlers.keys()
+                    {"channel_name": channel.name}
+                    for channel in self._update_handlers.keys()
                 ]
             }
         )

--- a/forwarder/update_handlers/create_update_handler.py
+++ b/forwarder/update_handlers/create_update_handler.py
@@ -20,6 +20,10 @@ def create_update_handler(
     fake_pv_period_ms: int,
     periodic_update_ms: Optional[int] = None,
 ) -> UpdateHandler:
+    if channel.name is None:
+        raise RuntimeError(
+            f"PV name not specified when adding handler for channel {channel.name}"
+        )
     if channel.output_topic is None:
         raise RuntimeError(
             f"Output topic not specified when adding handler for channel {channel.name}"

--- a/forwarder/update_handlers/create_update_handler.py
+++ b/forwarder/update_handlers/create_update_handler.py
@@ -1,12 +1,15 @@
 from forwarder.parse_config_update import EpicsProtocol
 from forwarder.parse_config_update import Channel as ConfigChannel
 from forwarder.kafka.kafka_producer import KafkaProducer
-from typing import Optional
+from typing import Optional, Union
 from caproto.threading.client import Context as CAContext
 from p4p.client.thread import Context as PVAContext
 from forwarder.update_handlers.ca_update_handler import CAUpdateHandler
 from forwarder.update_handlers.pva_update_handler import PVAUpdateHandler
 from forwarder.update_handlers.fake_update_handler import FakeUpdateHandler
+
+
+UpdateHandler = Union[CAUpdateHandler, PVAUpdateHandler, FakeUpdateHandler]
 
 
 def create_update_handler(
@@ -16,7 +19,15 @@ def create_update_handler(
     channel: ConfigChannel,
     fake_pv_period_ms: int,
     periodic_update_ms: Optional[int] = None,
-):
+) -> UpdateHandler:
+    if channel.output_topic is None:
+        raise RuntimeError(
+            f"Output topic not specified when adding handler for channel {channel.name}"
+        )
+    if channel.schema is None:
+        raise RuntimeError(
+            f"Schema not specified when adding handler for channel {channel.name}"
+        )
     if channel.protocol == EpicsProtocol.PVA:
         return PVAUpdateHandler(
             producer,
@@ -43,3 +54,4 @@ def create_update_handler(
             channel.schema,
             fake_pv_period_ms,
         )
+    raise RuntimeError("Unexpected EpicsProtocol in create_update_handler")

--- a/forwarder_launch.py
+++ b/forwarder_launch.py
@@ -30,6 +30,8 @@ if __name__ == "__main__":
     # EPICS
     ca_ctx = CaContext()
     pva_ctx = PvaContext("pva", nt=False)
+    # Using dictionary with Channel as key to ensure we avoid having multiple handlers active for
+    # identical configurations: serialising updates from same pv with same schema and publishing to same topic
     update_handlers: Dict[Channel, UpdateHandler] = dict()
 
     # Kafka

--- a/forwarder_launch.py
+++ b/forwarder_launch.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
         graylog_logger_address=args.graylog_logger_address,
     )
     version = get_version()
-    logger.info(f"Forwarder v{version} started")
+    logger.info(f"Forwarder v{version} started, service Id: {args.service_id}")
 
     # EPICS
     ca_ctx = CaContext()

--- a/forwarder_launch.py
+++ b/forwarder_launch.py
@@ -12,6 +12,8 @@ from forwarder.parse_config_update import parse_config_update
 from forwarder.status_reporter import StatusReporter
 from forwarder.parse_commandline_args import parse_args, get_version
 from forwarder.handle_config_change import handle_configuration_change
+from forwarder.update_handlers.create_update_handler import UpdateHandler
+from forwarder.parse_config_update import Channel
 
 
 if __name__ == "__main__":
@@ -28,7 +30,7 @@ if __name__ == "__main__":
     # EPICS
     ca_ctx = CaContext()
     pva_ctx = PvaContext("pva", nt=False)
-    update_handlers: Dict = dict()
+    update_handlers: Dict[Channel, UpdateHandler] = dict()
 
     # Kafka
     producer = create_producer(args.output_broker)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 wheel
-caproto >= 0.5.2
-p4p >= 3.5.0
-confluent_kafka
+caproto == 0.5.2
+p4p == 3.5.1
+confluent_kafka == 1.5.0
 flatbuffers == 1.11
 graypy
-numpy
+numpy == 1.19.1
 attrs
 ConfigArgParse
 ess-streaming-data-types >= 0.9.0

--- a/system_tests/compose/docker-compose-kafka.yml
+++ b/system_tests/compose/docker-compose-kafka.yml
@@ -15,7 +15,7 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_MESSAGE_MAX_BYTES: 10000000
       KAFKA_BROKER_ID: 0
-      KAFKA_CREATE_TOPICS: "TEST_forwarderConfig:1:1,TEST_forwarderData_2_partitions:2:1,TEST_forwarderData_0:1:1,TEST_forwarderData_1:1:1,TEST_forwarderData_2:1:1,TEST_forwarderData_change_config:1:1,TEST_forwarderData_connection_status:1:1"
+      KAFKA_CREATE_TOPICS: "TEST_forwarderConfig:1:1,TEST_forwarderData_2_partitions:2:1,TEST_forwarderData_0:1:1,TEST_forwarderData_1:1:1,TEST_forwarderData_2:1:1,TEST_forwarderData_change_config:1:1,TEST_forwarderData_connection_status:1:1,TEST_forwarderData_fake:1:1,TEST_forwarderData_idle_updates:1:1"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 

--- a/tests/handle_config_change_test.py
+++ b/tests/handle_config_change_test.py
@@ -1,0 +1,124 @@
+from forwarder.handle_config_change import handle_configuration_change
+from tests.kafka.fake_producer import FakeProducer
+import logging
+from forwarder.parse_config_update import (
+    ConfigUpdate,
+    CommandType,
+    Channel,
+    EpicsProtocol,
+)
+from forwarder.update_handlers.create_update_handler import UpdateHandler
+from typing import Dict, List
+import pytest
+
+
+class StubStatusReporter:
+    def report_status(self):
+        pass
+
+
+class StubUpdateHandler:
+    def stop(self):
+        pass
+
+
+_logger = logging.getLogger("stub_for_use_in_tests")
+_logger.addHandler(logging.NullHandler())
+
+
+def _get_channel_names(update_handlers: Dict[Channel, UpdateHandler]) -> List[str]:
+    return [channel.name for channel in update_handlers.keys()]
+
+
+@pytest.fixture(scope="function")
+def update_handlers():
+    """
+    Fixture for creating update handlers to ensure they get cleaned up whether the test passes or not
+    """
+    update_handlers: Dict[Channel, UpdateHandler] = {}
+    yield update_handlers
+
+    # Clean up
+    for _, handler in update_handlers.items():
+        handler.stop()
+
+
+def test_no_change_to_empty_update_handlers_when_malformed_config_update_handled(
+    update_handlers,
+):
+    status_reporter = StubStatusReporter()
+    producer = FakeProducer()
+    config_update = ConfigUpdate(CommandType.MALFORMED, None)
+
+    handle_configuration_change(config_update, 20000, None, update_handlers, producer, None, None, _logger, status_reporter)  # type: ignore
+    assert not update_handlers
+
+
+def test_no_change_to_update_handlers_when_malformed_config_update_handled(
+    update_handlers,
+):
+    status_reporter = StubStatusReporter()
+    producer = FakeProducer()
+    config_update = ConfigUpdate(CommandType.MALFORMED, None)
+
+    existing_channel_name = "test_channel"
+    update_handlers[Channel(existing_channel_name, EpicsProtocol.NONE, None, None)] = StubUpdateHandler()  # type: ignore
+    handle_configuration_change(config_update, 20000, None, update_handlers, producer, None, None, _logger, status_reporter)  # type: ignore
+    assert len(update_handlers) == 1
+    assert existing_channel_name in _get_channel_names(update_handlers)
+
+
+def test_all_update_handlers_are_removed_when_removeall_config_update_is_handled(
+    update_handlers,
+):
+    status_reporter = StubStatusReporter()
+    producer = FakeProducer()
+    config_update = ConfigUpdate(CommandType.REMOVE_ALL, None)
+
+    update_handlers[Channel("test_channel_1", EpicsProtocol.NONE, None, None)] = StubUpdateHandler()  # type: ignore
+    update_handlers[Channel("test_channel_2", EpicsProtocol.NONE, None, None)] = StubUpdateHandler()  # type: ignore
+    handle_configuration_change(config_update, 20000, None, update_handlers, producer, None, None, _logger, status_reporter)  # type: ignore
+    assert not update_handlers
+
+
+def test_update_handlers_are_removed_when_remove_config_update_is_handled(
+    update_handlers,
+):
+    status_reporter = StubStatusReporter()
+    producer = FakeProducer()
+    channel_name_1 = "test_channel_1"
+    channel_name_2 = "test_channel_2"
+    config_update = ConfigUpdate(
+        CommandType.REMOVE, (Channel(channel_name_1, EpicsProtocol.NONE, None, None),),
+    )
+
+    update_handlers[Channel(channel_name_1, EpicsProtocol.NONE, None, None)] = StubUpdateHandler()  # type: ignore
+    update_handlers[Channel(channel_name_2, EpicsProtocol.NONE, None, None)] = StubUpdateHandler()  # type: ignore
+    handle_configuration_change(config_update, 20000, None, update_handlers, producer, None, None, _logger, status_reporter)  # type: ignore
+    assert len(update_handlers) == 1
+    assert channel_name_2 in _get_channel_names(
+        update_handlers
+    ), "Expected handler for channel_name_1 to have been removed, leaving only channel_name_2"
+
+
+def test_update_handlers_are_added_when_add_config_update_is_handled(update_handlers):
+    status_reporter = StubStatusReporter()
+    producer = FakeProducer()
+    channel_name_1 = "test_channel_1"
+    channel_name_2 = "test_channel_2"
+    config_update = ConfigUpdate(
+        CommandType.ADD,
+        (
+            Channel(channel_name_1, EpicsProtocol.FAKE, "output_topic", "f142"),
+            Channel(channel_name_2, EpicsProtocol.FAKE, "output_topic", "f142"),
+        ),
+    )
+
+    handle_configuration_change(config_update, 20000, None, update_handlers, producer, None, None, _logger, status_reporter)  # type: ignore
+    assert len(update_handlers) == 2
+    assert channel_name_1 in _get_channel_names(update_handlers)
+    assert channel_name_2 in _get_channel_names(update_handlers)
+
+    # Clean up
+    for _, handler in update_handlers.items():
+        handler.stop()

--- a/tests/handle_config_change_test.py
+++ b/tests/handle_config_change_test.py
@@ -161,7 +161,7 @@ def test_update_handlers_can_be_removed_by_schema_and_topic(update_handlers,):
     # Only the handler with the channel matching provided topic AND schema should be removed
     config_update = ConfigUpdate(
         CommandType.REMOVE,
-        (Channel(None, EpicsProtocol.NONE, topic_name_1, schema_2),),
+        (Channel(None, EpicsProtocol.NONE, topic_name_2, schema_1),),
     )
 
     handle_configuration_change(config_update, 20000, None, update_handlers, producer, None, None, _logger, status_reporter)  # type: ignore

--- a/tests/handle_config_change_test.py
+++ b/tests/handle_config_change_test.py
@@ -119,6 +119,40 @@ def test_update_handlers_are_added_when_add_config_update_is_handled(update_hand
     assert channel_name_1 in _get_channel_names(update_handlers)
     assert channel_name_2 in _get_channel_names(update_handlers)
 
-    # Clean up
-    for _, handler in update_handlers.items():
-        handler.stop()
+
+def test_can_add_multiple_channels_with_same_name_if_protocol_topic_or_schema_are_different(
+    update_handlers,
+):
+    status_reporter = StubStatusReporter()
+    producer = FakeProducer()
+    channel_name = "test_channel"
+    test_channel_1 = Channel(channel_name, EpicsProtocol.FAKE, "output_topic", "f142")
+    test_channel_2 = Channel(channel_name, EpicsProtocol.FAKE, "output_topic_2", "f142")
+    test_channel_3 = Channel(channel_name, EpicsProtocol.FAKE, "output_topic", "tdct")
+    config_update = ConfigUpdate(
+        CommandType.ADD, (test_channel_1, test_channel_2, test_channel_3,),
+    )
+
+    handle_configuration_change(config_update, 20000, None, update_handlers, producer, None, None, _logger, status_reporter)  # type: ignore
+    assert len(update_handlers) == 3
+    assert test_channel_1 in update_handlers.keys()
+    assert test_channel_2 in update_handlers.keys()
+    assert test_channel_3 in update_handlers.keys()
+
+
+def test_identical_configurations_are_not_added(update_handlers,):
+    status_reporter = StubStatusReporter()
+    producer = FakeProducer()
+    channel_name = "test_channel"
+    test_channel_1 = Channel(channel_name, EpicsProtocol.FAKE, "output_topic", "f142")
+    test_channel_2 = Channel(channel_name, EpicsProtocol.FAKE, "output_topic", "f142")
+    test_channel_3 = Channel(channel_name, EpicsProtocol.FAKE, "output_topic", "f142")
+    config_update = ConfigUpdate(
+        CommandType.ADD, (test_channel_1, test_channel_2, test_channel_3,),
+    )
+
+    handle_configuration_change(config_update, 20000, None, update_handlers, producer, None, None, _logger, status_reporter)  # type: ignore
+    assert (
+        len(update_handlers) == 1
+    ), "Only expect one channel to be added as others requested were identical"
+    assert test_channel_1 in update_handlers.keys()

--- a/tests/handle_config_change_test.py
+++ b/tests/handle_config_change_test.py
@@ -27,7 +27,9 @@ _logger.addHandler(logging.NullHandler())
 
 
 def _get_channel_names(update_handlers: Dict[Channel, UpdateHandler]) -> List[str]:
-    return [channel.name for channel in update_handlers.keys()]
+    return [
+        channel.name for channel in update_handlers.keys() if channel.name is not None
+    ]
 
 
 @pytest.fixture(scope="function")

--- a/tests/parse_config_update_test.py
+++ b/tests/parse_config_update_test.py
@@ -152,3 +152,14 @@ def test_parse_streams_skips_stream_info_if_remove_config_and_channel_name_schem
     config_message = deserialise_rf5k(message)
     streams = tuple(_parse_streams(CommandType.REMOVE, config_message.streams))
     assert not streams
+
+
+def test_parse_streams_skips_stream_info_if_remove_config_and_schema_present_but_not_recognised():
+    nonexistent_schema = "NONEXISTENT"
+    message = serialise_rf5k(
+        UpdateType.REMOVE,
+        [StreamInfo("test_channel", nonexistent_schema, "output_topic", Protocol.PVA)],
+    )
+    config_message = deserialise_rf5k(message)
+    streams = tuple(_parse_streams(CommandType.REMOVE, config_message.streams))
+    assert not streams

--- a/tests/parse_config_update_test.py
+++ b/tests/parse_config_update_test.py
@@ -51,17 +51,6 @@ def test_parse_streams_skips_stream_info_if_add_config_and_channel_not_specified
     assert not streams
 
 
-def test_parse_streams_skips_stream_info_if_remove_config_and_channel_not_specified():
-    empty_channel = ""
-    message = serialise_rf5k(
-        UpdateType.REMOVE,
-        [StreamInfo(empty_channel, "f142", "output_topic", Protocol.PVA)],
-    )
-    config_message = deserialise_rf5k(message)
-    streams = tuple(_parse_streams(CommandType.ADD, config_message.streams))
-    assert not streams
-
-
 def test_parse_streams_skips_stream_info_if_add_config_and_schema_not_specified():
     empty_schema = ""
     message = serialise_rf5k(
@@ -94,18 +83,6 @@ def test_parse_streams_skips_stream_info_if_add_config_and_schema_not_recognised
     assert not streams
 
 
-def test_parse_streams_parses_valid_remove_config():
-    test_channel_name = "test_channel"
-    message = serialise_rf5k(
-        UpdateType.REMOVE,
-        [StreamInfo(test_channel_name, "f142", "output_topic", Protocol.PVA)],
-    )
-    config_message = deserialise_rf5k(message)
-    streams = tuple(_parse_streams(CommandType.ADD, config_message.streams))
-    assert len(streams) == 1
-    assert streams[0].name == test_channel_name
-
-
 def test_parse_streams_parses_valid_add_config():
     test_channel_name = "test_channel"
     message = serialise_rf5k(
@@ -134,3 +111,44 @@ def test_parse_streams_parses_valid_stream_after_skipping_invalid_stream():
     streams = tuple(_parse_streams(CommandType.ADD, config_message.streams))
     assert len(streams) == 1
     assert streams[0].name == valid_stream_channel_name
+
+
+def test_remove_config_is_valid_with_all_channel_info_specified():
+    test_channel_name = "test_channel"
+    message = serialise_rf5k(
+        UpdateType.REMOVE,
+        [StreamInfo(test_channel_name, "f142", "output_topic", Protocol.PVA)],
+    )
+    config_message = deserialise_rf5k(message)
+    streams = tuple(_parse_streams(CommandType.REMOVE, config_message.streams))
+    assert len(streams) == 1
+    assert streams[0].name == test_channel_name
+
+
+def test_remove_config_is_valid_if_channel_name_not_specified_but_schema_is():
+    test_schema = "f142"
+    message = serialise_rf5k(
+        UpdateType.REMOVE, [StreamInfo("", test_schema, "", Protocol.PVA)],
+    )
+    config_message = deserialise_rf5k(message)
+    streams = tuple(_parse_streams(CommandType.REMOVE, config_message.streams))
+    assert len(streams) == 1
+    assert streams[0].schema == test_schema
+
+
+def test_remove_config_is_valid_if_channel_name_not_specified_but_topic_is():
+    test_topic = "output_topic"
+    message = serialise_rf5k(
+        UpdateType.REMOVE, [StreamInfo("", "", test_topic, Protocol.PVA)],
+    )
+    config_message = deserialise_rf5k(message)
+    streams = tuple(_parse_streams(CommandType.REMOVE, config_message.streams))
+    assert len(streams) == 1
+    assert streams[0].output_topic == test_topic
+
+
+def test_parse_streams_skips_stream_info_if_remove_config_and_channel_name_schema_and_topic_not_specified():
+    message = serialise_rf5k(UpdateType.REMOVE, [StreamInfo("", "", "", Protocol.PVA)],)
+    config_message = deserialise_rf5k(message)
+    streams = tuple(_parse_streams(CommandType.REMOVE, config_message.streams))
+    assert not streams

--- a/tests/status_reporter_test.py
+++ b/tests/status_reporter_test.py
@@ -4,6 +4,7 @@ from tests.kafka.fake_producer import FakeProducer
 import json
 from streaming_data_types.status_x5f2 import deserialise_x5f2
 import logging
+from forwarder.parse_config_update import Channel, EpicsProtocol
 
 
 logger = logging.getLogger("stub_for_use_in_tests")
@@ -16,7 +17,10 @@ def test_when_update_handlers_exist_their_channel_names_are_reported_in_status()
 
     # Normally the values in this dictionary are the update handler objects
     # but the StatusReporter only uses the keys
-    update_handlers = {test_channel_name_1: 1, test_channel_name_2: 2}
+    update_handlers = {
+        Channel(test_channel_name_1, EpicsProtocol.NONE, None, None): 1,
+        Channel(test_channel_name_2, EpicsProtocol.NONE, None, None): 2,
+    }
 
     fake_producer = FakeProducer()
     status_reporter = StatusReporter(update_handlers, fake_producer, "status_topic", "", "version", logger)  # type: ignore

--- a/tests/status_reporter_test.py
+++ b/tests/status_reporter_test.py
@@ -3,6 +3,11 @@ from typing import Dict
 from tests.kafka.fake_producer import FakeProducer
 import json
 from streaming_data_types.status_x5f2 import deserialise_x5f2
+import logging
+
+
+logger = logging.getLogger("stub_for_use_in_tests")
+logger.addHandler(logging.NullHandler())
 
 
 def test_when_update_handlers_exist_their_channel_names_are_reported_in_status():
@@ -14,7 +19,7 @@ def test_when_update_handlers_exist_their_channel_names_are_reported_in_status()
     update_handlers = {test_channel_name_1: 1, test_channel_name_2: 2}
 
     fake_producer = FakeProducer()
-    status_reporter = StatusReporter(update_handlers, fake_producer, "status_topic", "", "version")  # type: ignore
+    status_reporter = StatusReporter(update_handlers, fake_producer, "status_topic", "", "version", logger)  # type: ignore
     status_reporter.report_status()
 
     if fake_producer.published_payload is not None:
@@ -33,7 +38,7 @@ def test_when_no_update_handlers_exist_no_streams_are_present_in_reported_status
     update_handlers: Dict = {}
 
     fake_producer = FakeProducer()
-    status_reporter = StatusReporter(update_handlers, fake_producer, "status_topic", "", "version")  # type: ignore
+    status_reporter = StatusReporter(update_handlers, fake_producer, "status_topic", "", "version", logger)  # type: ignore
     status_reporter.report_status()
 
     if fake_producer.published_payload is not None:
@@ -49,7 +54,7 @@ def test_status_message_contains_service_id():
     update_handlers: Dict = {}
 
     fake_producer = FakeProducer()
-    status_reporter = StatusReporter(update_handlers, fake_producer, "status_topic", service_id, "version")  # type: ignore
+    status_reporter = StatusReporter(update_handlers, fake_producer, "status_topic", service_id, "version", logger)  # type: ignore
     status_reporter.report_status()
 
     if fake_producer.published_payload is not None:


### PR DESCRIPTION
Closes #39
Closes #38 

Use full Channel object as update_handlers dictionary key instead of only the pv name. This allows multiple configurations for the same pv name, for example to serialise updates with different schemas or output to multiple topics (#38). It also allows removing configurations matching any subset of pv name, output topic and schema (#39).
I also extracted config change handling to a separate file so that I could add unit tests.