### PR TITLE
Allow wildcards when removing configurations by topic or channel name

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ This sets where the data is forwarded to as it is not configurable separately fo
 see [C++ Forwarder features not replicated here](#c++-forwarder-features-not-replicated-here). 
 
 
+## Configuring EPICS PVs to be forwarded
+
+Adding or remvoing PVs to be forwarded is done by publishing configuration change messages to the configuration 
+topic specified in the command line arguments. Such messages must be serialised as FlatBuffers using
+[this schema](). Support for serialising and deserialising these messages in python in available in the
+[ess-streaming-data-types](https://pypi.org/project/ess-streaming-data-types/) library.
+
+Note that when removing configured streams, not all fields in the `Stream` table of the schema need to be populated.
+Missing or empty strings in the channel name, output topic and schema fields match all stream configurations.
+At least one field must be populated; to remove all configurations a REMOVEALL configuration change can be used instead.
+
+Single-character "? and multi-character "*" wildcards are allowed to be used in the channel name and output topic fields.
+In conjunction with naming conventions for EPICS channel names and Kafka topics this can be used to carry out operations
+such as clearing all configured streams for a particular instrument. 
+
 ## Docker
 
 To build a docker image

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,6 @@
 # Changes
 
 *Add to release notes and clear this list when creating a new release*
+
+- When requesting to remove stream configurations, wildcards '*' and '?' can now be
+used in the output topic and channel name fields.

--- a/system_tests/README.md
+++ b/system_tests/README.md
@@ -29,13 +29,13 @@ Append `--wait-to-attach-debugger` to the `pytest` command to pause running the 
 been attached. This option only works in conjunction with the `--local-build` option. A message will appear in the 
 console and it will report the process ID and wait for user input before continuing. However note that the Forwarder 
 process itself continues running so you may need to find the debugger message amoung other output, I haven't found a 
-solution to this as SIGSTOP seems to causes the Forwarder process to terminate rather than pause.  
+solution to this as SIGSTOP seems to causes the Forwarder process to terminate rather than pause.
 
 ### General Architecture
 
 The system tests use pytest for the test runner, and use separate fixtures for different configurations of the forwarder. 
 
-Firstly, the system tests attempt to build and tag the latest forwarder image. This can take a lot of time especially if something in conan has changed, as it has to reinstall all of the conan packages.
+Firstly, the system tests attempt to build and tag the latest forwarder image. This can take a few minutes if it needs to download the base docker images.
 
 The IOC, Kafka and Zookeeper containers are started with `docker-compose` and persist throughout all of the tests, and when finished will be stopped and removed. 
 

--- a/tests/handle_config_change_test.py
+++ b/tests/handle_config_change_test.py
@@ -293,6 +293,27 @@ def test_multicharacter_wildcard_can_be_used_to_remove_channels_by_name(
     assert test_channel_3 in update_handlers.keys()
 
 
+def test_wildcard_cannot_be_used_to_remove_channels_by_schema(update_handlers,):
+    # No wildcard matching on schemas because ? and * are allowed characters in schema identifiers
+
+    status_reporter = StubStatusReporter()
+    producer = FakeProducer()
+
+    test_channel_3 = Channel("channel_3", EpicsProtocol.NONE, "topic_3", "f142")
+    update_handlers[Channel("channel_1", EpicsProtocol.NONE, "topic_1", "f142")] = StubUpdateHandler()  # type: ignore
+    update_handlers[Channel("channel_2", EpicsProtocol.NONE, "topic_2", "f142")] = StubUpdateHandler()  # type: ignore
+    update_handlers[test_channel_3] = StubUpdateHandler()  # type: ignore
+
+    config_update = ConfigUpdate(
+        CommandType.REMOVE, (Channel(None, EpicsProtocol.NONE, None, "f?42"),),
+    )
+
+    handle_configuration_change(config_update, 20000, None, update_handlers, producer, None, None, _logger, status_reporter)  # type: ignore
+    assert (
+        len(update_handlers) == 3
+    ), "Expected no channels to be removed as ? is not treated as a wildcard when matching schemas"
+
+
 def test_update_handlers_are_added_when_add_config_update_is_handled(update_handlers):
     status_reporter = StubStatusReporter()
     producer = FakeProducer()

--- a/tests/handle_config_change_test.py
+++ b/tests/handle_config_change_test.py
@@ -211,6 +211,88 @@ def test_update_handlers_can_be_removed_by_name_and_schema(update_handlers,):
     assert test_channel_3 not in update_handlers.keys()
 
 
+def test_single_character_wildcard_can_be_used_to_remove_channels_by_topic(
+    update_handlers,
+):
+    status_reporter = StubStatusReporter()
+    producer = FakeProducer()
+
+    test_channel_3 = Channel("channel_3", EpicsProtocol.NONE, "topic_III", None)
+    update_handlers[Channel("channel_1", EpicsProtocol.NONE, "topic_1", None)] = StubUpdateHandler()  # type: ignore
+    update_handlers[Channel("channel_2", EpicsProtocol.NONE, "topic_2", None)] = StubUpdateHandler()  # type: ignore
+    update_handlers[test_channel_3] = StubUpdateHandler()  # type: ignore
+
+    config_update = ConfigUpdate(
+        CommandType.REMOVE, (Channel(None, EpicsProtocol.NONE, "topic_?", None),),
+    )
+
+    handle_configuration_change(config_update, 20000, None, update_handlers, producer, None, None, _logger, status_reporter)  # type: ignore
+    assert len(update_handlers) == 1
+    assert test_channel_3 in update_handlers.keys()
+
+
+def test_multicharacter_wildcard_can_be_used_to_remove_channels_by_topic(
+    update_handlers,
+):
+    status_reporter = StubStatusReporter()
+    producer = FakeProducer()
+
+    test_channel_3 = Channel("channel_3", EpicsProtocol.NONE, "topic_3", None)
+    update_handlers[Channel("channel_1", EpicsProtocol.NONE, "first_topic", None)] = StubUpdateHandler()  # type: ignore
+    update_handlers[Channel("channel_2", EpicsProtocol.NONE, "second_topic", None)] = StubUpdateHandler()  # type: ignore
+    update_handlers[test_channel_3] = StubUpdateHandler()  # type: ignore
+
+    config_update = ConfigUpdate(
+        CommandType.REMOVE, (Channel(None, EpicsProtocol.NONE, "*_topic", None),),
+    )
+
+    handle_configuration_change(config_update, 20000, None, update_handlers, producer, None, None, _logger, status_reporter)  # type: ignore
+    assert len(update_handlers) == 1
+    assert test_channel_3 in update_handlers.keys()
+
+
+def test_single_character_wildcard_can_be_used_to_remove_channels_by_name(
+    update_handlers,
+):
+    status_reporter = StubStatusReporter()
+    producer = FakeProducer()
+
+    test_channel_3 = Channel("channel_III", EpicsProtocol.NONE, "topic_3", None)
+    update_handlers[Channel("channel_1", EpicsProtocol.NONE, "topic_1", None)] = StubUpdateHandler()  # type: ignore
+    update_handlers[Channel("channel_2", EpicsProtocol.NONE, "topic_2", None)] = StubUpdateHandler()  # type: ignore
+    update_handlers[test_channel_3] = StubUpdateHandler()  # type: ignore
+
+    config_update = ConfigUpdate(
+        CommandType.REMOVE, (Channel("channel_?", EpicsProtocol.NONE, None, None),),
+    )
+
+    handle_configuration_change(config_update, 20000, None, update_handlers, producer, None, None, _logger, status_reporter)  # type: ignore
+    assert len(update_handlers) == 1
+    assert test_channel_3 in update_handlers.keys()
+
+
+def test_multicharacter_wildcard_can_be_used_to_remove_channels_by_name(
+    update_handlers,
+):
+    status_reporter = StubStatusReporter()
+    producer = FakeProducer()
+
+    test_channel_3 = Channel("channel_3", EpicsProtocol.NONE, "topic_3", None)
+    update_handlers[Channel("first_channel", EpicsProtocol.NONE, "topic2", None)] = StubUpdateHandler()  # type: ignore
+    update_handlers[
+        Channel("second_channel", EpicsProtocol.NONE, "topic 1", None)
+    ] = StubUpdateHandler()  # type: ignore
+    update_handlers[test_channel_3] = StubUpdateHandler()  # type: ignore
+
+    config_update = ConfigUpdate(
+        CommandType.REMOVE, (Channel("*_channel", EpicsProtocol.NONE, None, None),),
+    )
+
+    handle_configuration_change(config_update, 20000, None, update_handlers, producer, None, None, _logger, status_reporter)  # type: ignore
+    assert len(update_handlers) == 1
+    assert test_channel_3 in update_handlers.keys()
+
+
 def test_update_handlers_are_added_when_add_config_update_is_handled(update_handlers):
     status_reporter = StubStatusReporter()
     producer = FakeProducer()


### PR DESCRIPTION
Closes DM-1634

Unit tests and impl use of single- or multi-character wildcards when matching output topic or channel names to remove existing configurations.