### PR TITLE
Added system test to check stored config is retrieved on start-up.

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -7,4 +7,6 @@ used in the output topic and channel name fields.
 
 - Can request Forwarder to store the current configuration and retrieve it when restarting.
 
-- Added more information to the README
+- Added more information to the README.
+
+- Added system test for stored config.

--- a/system_tests/compose/docker-compose-kafka.yml
+++ b/system_tests/compose/docker-compose-kafka.yml
@@ -15,7 +15,7 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_MESSAGE_MAX_BYTES: 10000000
       KAFKA_BROKER_ID: 0
-      KAFKA_CREATE_TOPICS: "TEST_forwarderConfig:1:1,TEST_forwarderData_2_partitions:2:1,TEST_forwarderData_0:1:1,TEST_forwarderData_1:1:1,TEST_forwarderData_2:1:1,TEST_forwarderData_change_config:1:1,TEST_forwarderData_connection_status:1:1,TEST_forwarderData_fake:1:1,TEST_forwarderData_idle_updates:1:1,TEST_forwarderStorage:1:1"
+      KAFKA_CREATE_TOPICS: "TEST_forwarderConfig:1:1,TEST_forwarderStatus:1:1,TEST_forwarderData_2_partitions:2:1,TEST_forwarderData_0:1:1,TEST_forwarderData_1:1:1,TEST_forwarderData_2:1:1,TEST_forwarderData_change_config:1:1,TEST_forwarderData_connection_status:1:1,TEST_forwarderData_fake:1:1,TEST_forwarderData_idle_updates:1:1,TEST_forwarderStorage:1:1"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 

--- a/system_tests/compose/docker-compose-kafka.yml
+++ b/system_tests/compose/docker-compose-kafka.yml
@@ -15,7 +15,7 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_MESSAGE_MAX_BYTES: 10000000
       KAFKA_BROKER_ID: 0
-      KAFKA_CREATE_TOPICS: "TEST_forwarderConfig:1:1,TEST_forwarderStatus:1:1,TEST_forwarderData_2_partitions:2:1,TEST_forwarderData_0:1:1,TEST_forwarderData_1:1:1,TEST_forwarderData_2:1:1,TEST_forwarderData_change_config:1:1,TEST_forwarderData_connection_status:1:1,TEST_forwarderData_fake:1:1,TEST_forwarderData_idle_updates:1:1,TEST_forwarderStorage:1:1"
+      KAFKA_CREATE_TOPICS: "TEST_forwarderConfig:1:1,TEST_forwarderData_2_partitions:2:1,TEST_forwarderData_0:1:1,TEST_forwarderData_1:1:1,TEST_forwarderData_2:1:1,TEST_forwarderData_change_config:1:1,TEST_forwarderData_connection_status:1:1,TEST_forwarderData_fake:1:1,TEST_forwarderData_idle_updates:1:1,TEST_forwarderStorage:1:1,TEST_forwarderStorageStatus:1:1"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 

--- a/system_tests/compose/docker-compose-kafka.yml
+++ b/system_tests/compose/docker-compose-kafka.yml
@@ -15,7 +15,7 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_MESSAGE_MAX_BYTES: 10000000
       KAFKA_BROKER_ID: 0
-      KAFKA_CREATE_TOPICS: "TEST_forwarderConfig:1:1,TEST_forwarderData_2_partitions:2:1,TEST_forwarderData_0:1:1,TEST_forwarderData_1:1:1,TEST_forwarderData_2:1:1,TEST_forwarderData_change_config:1:1,TEST_forwarderData_connection_status:1:1,TEST_forwarderData_fake:1:1,TEST_forwarderData_idle_updates:1:1"
+      KAFKA_CREATE_TOPICS: "TEST_forwarderConfig:1:1,TEST_forwarderData_2_partitions:2:1,TEST_forwarderData_0:1:1,TEST_forwarderData_1:1:1,TEST_forwarderData_2:1:1,TEST_forwarderData_change_config:1:1,TEST_forwarderData_connection_status:1:1,TEST_forwarderData_fake:1:1,TEST_forwarderData_idle_updates:1:1,TEST_forwarderStorage:1:1"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 

--- a/system_tests/compose/docker-compose-storage.yml
+++ b/system_tests/compose/docker-compose-storage.yml
@@ -1,0 +1,12 @@
+
+version: '2'
+
+services:
+  forwarder:
+    image: forwarder:latest
+    network_mode: "host"
+    volumes:
+      - ../config-files/forwarder_config_storage.ini:/forwarder_config_storage.ini
+      - ../logs/:/forwarder_logs/
+    environment:
+      CONFIG_FILE: "/forwarder_config_storage.ini"

--- a/system_tests/config-files/forwarder_config_storage.ini
+++ b/system_tests/config-files/forwarder_config_storage.ini
@@ -1,4 +1,4 @@
-status-topic=localhost:9092/TEST_forwarderStatus
+status-topic=localhost:9092/TEST_forwarderStorageStatus
 config-topic=localhost:9092/TEST_forwarderConfig
 storage-topic=localhost:9092/TEST_forwarderStorage
 log-file=/forwarder_logs/forwarder_tests_forwarding.log

--- a/system_tests/config-files/forwarder_config_storage.ini
+++ b/system_tests/config-files/forwarder_config_storage.ini
@@ -1,0 +1,6 @@
+status-topic=localhost:9092/TEST_forwarderStatus
+config-topic=localhost:9092/TEST_forwarderConfig
+storage-topic=localhost:9092/TEST_forwarderStorage
+log-file=/forwarder_logs/forwarder_tests_forwarding.log
+verbosity=Trace
+output-broker=localhost:9092

--- a/system_tests/conftest.py
+++ b/system_tests/conftest.py
@@ -7,6 +7,16 @@ import docker
 from time import sleep
 from subprocess import Popen
 import warnings
+from streaming_data_types.forwarder_config_update_rf5k import (
+    serialise_rf5k,
+    StreamInfo,
+    Protocol,
+)
+from streaming_data_types.fbschemas.forwarder_config_update_rf5k.UpdateType import (
+    UpdateType,
+)
+
+from .helpers.PVs import PVSTR, PVLONG
 
 
 LOCAL_BUILD = "--local-build"
@@ -260,17 +270,6 @@ def docker_compose_storage(request):
     """
     :type request: _pytest.python.FixtureRequest
     """
-    from streaming_data_types.forwarder_config_update_rf5k import (
-        serialise_rf5k,
-        StreamInfo,
-        Protocol,
-    )
-    from streaming_data_types.fbschemas.forwarder_config_update_rf5k.UpdateType import (
-        UpdateType,
-    )
-
-    from .helpers.PVs import PVSTR, PVLONG
-
     print("Started preparing test environment...", flush=True)
 
     # Push old configuration into kafka

--- a/system_tests/conftest.py
+++ b/system_tests/conftest.py
@@ -289,7 +289,7 @@ def docker_compose_storage(request):
     # Options must be given as long form
     options = common_options
     options["--project-name"] = "forwarderStorage"
-    options["--file"] = ["compose/docker-compose-forwarding.yml"]
+    options["--file"] = ["compose/docker-compose-storage.yml"]
 
     build_and_run(
         options, request, "forwarder_config_storage.ini", "forwarder_tests.log"

--- a/system_tests/test_config_storage.py
+++ b/system_tests/test_config_storage.py
@@ -6,7 +6,7 @@ from streaming_data_types.status_x5f2 import deserialise_x5f2
 
 def test_on_starting_stored_config_is_retrieved(docker_compose_storage):
     cons = create_consumer("latest")
-    status_topic = "TEST_forwarderStatus"
+    status_topic = "TEST_forwarderStorageStatus"
     cons.subscribe([status_topic])
 
     status_msg, _ = poll_for_valid_message(cons, expected_file_identifier=None)

--- a/system_tests/test_config_storage.py
+++ b/system_tests/test_config_storage.py
@@ -1,0 +1,30 @@
+from .helpers.kafka_helpers import create_consumer, poll_for_valid_message
+from .helpers.PVs import PVSTR, PVLONG
+import json
+from streaming_data_types.status_x5f2 import deserialise_x5f2
+
+
+def test_on_starting_stored_config_is_retrieved(docker_compose_storage):
+    cons = create_consumer("latest")
+    status_topic = "TEST_forwarderStatus"
+    cons.subscribe([status_topic])
+
+    status_msg, _ = poll_for_valid_message(cons, expected_file_identifier=None)
+
+    status_msg = deserialise_x5f2(status_msg)
+    status_json = json.loads(status_msg.status_json)
+    names_of_channels_being_forwarded = {
+        stream["channel_name"] for stream in status_json["streams"]
+    }
+    expected_names_of_channels_being_forwarded = {PVSTR, PVLONG}
+
+    assert (
+        expected_names_of_channels_being_forwarded == names_of_channels_being_forwarded
+    ), (
+        f"Expect these channels to be configured as forwarded: "
+        f"{expected_names_of_channels_being_forwarded}, "
+        f"but status message report these as forwarded: "
+        f"{names_of_channels_being_forwarded}"
+    )
+
+    cons.close()


### PR DESCRIPTION
Ugly little test to check that the stored config is retrieved on start-up.

Test for checking that they are saved is not required as that is covered in the unit tests (handle_config_change_test.py).