### PR TITLE
Update precommit hooks and static analysis tool versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: stable
+    rev: 20.8b1
     hooks:
     - id: black
       language_version: python3
 -   repo: https://github.com/pycqa/flake8
-    rev: 3.8.3
+    rev: 3.8.4
     hooks:
     - id: flake8
 -   repo: https://github.com/pre-commit/mirrors-mypy.git
-    rev: v0.730
+    rev: v0.790
     hooks:
     -   id: mypy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,13 @@
 # Development requirements
 
 -r requirements.txt
-black
 pre-commit
 pytest
 pytest-cov
-flake8
-mypy
+# Pin to match versions in precommit hooks
+black==20.8b1
+flake8==3.8.4
+mypy==v0.790
 
 # For system tests
 docker-compose


### PR DESCRIPTION
~Rebase on master after #57 is merged.~ done

We've had problems with precommit hook versions not matching what is used in the CI checks. Pinning both solves this problem, although we'll have to remember to update them every so often.