### PR TITLE
Handle exception when message has wrong schema

### DIFF
--- a/forwarder/parse_config_update.py
+++ b/forwarder/parse_config_update.py
@@ -2,6 +2,7 @@ from forwarder.application_logger import get_logger
 import attr
 from enum import Enum
 from typing import Tuple, Generator, Optional, List
+from streaming_data_types.exceptions import WrongSchemaException
 from streaming_data_types.forwarder_config_update_rf5k import (
     deserialise_rf5k,
     StreamInfo,
@@ -68,6 +69,9 @@ def parse_config_update(config_update_payload: bytes) -> ConfigUpdate:
         logger.warning(
             "Unable to deserialise payload of received configuration update message"
         )
+        return ConfigUpdate(CommandType.MALFORMED, None)
+    except WrongSchemaException:
+        logger.warning("Ignoring received message as it had the wrong schema")
         return ConfigUpdate(CommandType.MALFORMED, None)
 
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ graypy
 numpy == 1.19.1
 attrs
 ConfigArgParse
-ess-streaming-data-types >= 0.9.4
+ess-streaming-data-types >= 0.9.6

--- a/system_tests/conftest.py
+++ b/system_tests/conftest.py
@@ -104,6 +104,7 @@ common_options = {
     "--tail": "all",
     "--detach": True,
     "--build": False,
+    "--no-log-prefix": False,
 }
 
 


### PR DESCRIPTION
The python-streaming-data-types module changed to throw exceptions if the schema is wrong, this change allows us to support it.