### PR TITLE
Make systemtests robust to slow SoftIOC startup

### DIFF
--- a/system_tests/helpers/epics_helpers.py
+++ b/system_tests/helpers/epics_helpers.py
@@ -10,7 +10,7 @@ def change_pv_value(pvname, value):
     :param value: PV value to change to
     :return: none
     """
-    response = epics_write(pvname, value, notify=True)
+    response = epics_write(pvname, value, notify=True, timeout=10)
     print(f"Updating PV {pvname} value to {value}")
     print(f"{response}\n", flush=True)
 

--- a/system_tests/test_forwarding.py
+++ b/system_tests/test_forwarding.py
@@ -29,6 +29,7 @@ from .helpers.f142_logdata.AlarmSeverity import AlarmSeverity
 from .helpers.f142_logdata.AlarmStatus import AlarmStatus
 import pytest
 from streaming_data_types.status_x5f2 import deserialise_x5f2
+from caproto._utils import CaprotoTimeoutError
 
 CONFIG_TOPIC = "TEST_forwarderConfig"
 INITIAL_STRING_VALUE = "test"
@@ -56,7 +57,15 @@ def setup_and_teardown_function(request):
     }
 
     for key, value in initial_values.items():
-        change_pv_value(key, value)
+        pv_set = False
+        attempts = 0
+        while not pv_set and attempts < 10:
+            try:
+                change_pv_value(key, value)
+            except CaprotoTimeoutError:
+                attempts += 1
+                continue
+            pv_set = True
 
     sleep(1)
 


### PR DESCRIPTION
Closes #63 

Retries setting initial PV values up to 10 times. This stops the system tests from failing if the SoftIOC container is slower to start than the Kafka broker.