### PR TITLE
Try Redpanda

### DIFF
--- a/system_tests/compose/docker-compose-kafka.yml
+++ b/system_tests/compose/docker-compose-kafka.yml
@@ -3,27 +3,20 @@ version: '2'
 
 services:
   kafka:
-    image: wurstmeister/kafka:2.12-2.1.0
-    depends_on:
-      - zookeeper
+    image: vectorized/redpanda:latest
     hostname: kafka
     ports:
       - "9092:9092"
-    environment:
-      KAFKA_ADVERTISED_HOST_NAME: localhost
-      KAFKA_ADVERTISED_PORT: 9092
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_MESSAGE_MAX_BYTES: 10000000
-      KAFKA_BROKER_ID: 0
-      KAFKA_CREATE_TOPICS: "TEST_forwarderConfig:1:1,TEST_forwarderData_2_partitions:2:1,TEST_forwarderData_0:1:1,TEST_forwarderData_1:1:1,TEST_forwarderData_2:1:1,TEST_forwarderData_change_config:1:1,TEST_forwarderData_connection_status:1:1,TEST_forwarderData_fake:1:1,TEST_forwarderData_idle_updates:1:1,TEST_forwarderStorage:1:1,TEST_forwarderStorageStatus:1:1"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-
-  zookeeper:
-    image: zookeeper:3.4
 
   ioc:
     image: screamingudder/softioc:69433bc
     stdin_open: true
     tty: true
     network_mode: "host"
+
+  rpk_admin:
+    image: vectorized/redpanda:latest
+    stdin_open: true
+    tty: true
+    network_mode: "host"
+    entrypoint: bash


### PR DESCRIPTION
*DO NOT MERGE. THIS IS  AN EXPERIMENT*

[Redpanda](https://vectorized.io/) is a C++ implementation of the Kafka broker. It claims to have performance advantages over Kafka, as well as the advantage of not requiring Zookeeper.

Here I've tried swapping out Kafka+Zookeeper for Redpanda in the system tests... looks promising! Redpanda starts up much faster than Kafka+Zookeeper.
I had to make a small change to the test setup code as it does not yet support the Admin API, but otherwise it was simply a case of replacing the containers in the docker-compose file.