### PR TITLE
Fix minor race condition

### DIFF
--- a/forwarder/update_handlers/ca_update_handler.py
+++ b/forwarder/update_handlers/ca_update_handler.py
@@ -39,13 +39,6 @@ class CAUpdateHandler:
         self._logger = get_logger()
         self._producer = producer
         self._output_topic = output_topic
-        (self._pv,) = context.get_pvs(
-            pv_name, connection_state_callback=self._connection_state_callback
-        )
-        # Subscribe with "data_type='time'" to get timestamp and alarm fields
-        sub = self._pv.subscribe(data_type="time")
-        sub.add_callback(self._monitor_callback)
-
         self._cached_update: Optional[Tuple[ReadNotifyResponse, int]] = None
         self._output_type = None
         self._repeating_timer = None
@@ -57,6 +50,13 @@ class CAUpdateHandler:
             raise ValueError(
                 f"{schema} is not a recognised supported schema, use one of {list(schema_publishers.keys())}"
             )
+
+        (self._pv,) = context.get_pvs(
+            pv_name, connection_state_callback=self._connection_state_callback
+        )
+        # Subscribe with "data_type='time'" to get timestamp and alarm fields
+        sub = self._pv.subscribe(data_type="time")
+        sub.add_callback(self._monitor_callback)
 
         if periodic_update_ms is not None:
             self._repeating_timer = RepeatTimer(

--- a/forwarder/update_handlers/pva_update_handler.py
+++ b/forwarder/update_handlers/pva_update_handler.py
@@ -54,6 +54,13 @@ class PVAUpdateHandler:
         self._repeating_timer = None
         self._cache_lock = Lock()
 
+        try:
+            self._message_publisher = schema_publishers[schema]
+        except KeyError:
+            raise ValueError(
+                f"{schema} is not a recognised supported schema, use one of {list(schema_publishers.keys())}"
+            )
+
         request = context.makeRequest("field(value,timeStamp,alarm)")
         self._sub = context.monitor(
             self._pv_name,
@@ -61,13 +68,6 @@ class PVAUpdateHandler:
             request=request,
             notify_disconnect=True,
         )
-
-        try:
-            self._message_publisher = schema_publishers[schema]
-        except KeyError:
-            raise ValueError(
-                f"{schema} is not a recognised supported schema, use one of {list(schema_publishers.keys())}"
-            )
 
         if periodic_update_ms is not None:
             self._repeating_timer = RepeatTimer(

--- a/forwarder/update_handlers/pva_update_handler.py
+++ b/forwarder/update_handlers/pva_update_handler.py
@@ -48,12 +48,12 @@ class PVAUpdateHandler:
         self._logger = get_logger()
         self._producer = producer
         self._output_topic = output_topic
+        self._pv_name = pv_name
 
         request = context.makeRequest("field(value,timeStamp,alarm)")
         self._sub = context.monitor(
             pv_name, self._monitor_callback, request=request, notify_disconnect=True
         )
-        self._pv_name = pv_name
 
         self._cached_update: Optional[Tuple[Value, int]] = None
         self._output_type = None

--- a/forwarder/update_handlers/pva_update_handler.py
+++ b/forwarder/update_handlers/pva_update_handler.py
@@ -49,17 +49,16 @@ class PVAUpdateHandler:
         self._producer = producer
         self._output_topic = output_topic
         self._pv_name = pv_name
-
-        request = context.makeRequest("field(value,timeStamp,alarm)")
-        self._sub = context.monitor(
-            pv_name, self._monitor_callback, request=request, notify_disconnect=True
-        )
-
         self._cached_update: Optional[Tuple[Value, int]] = None
         self._output_type = None
         self._stop_timer_flag = Event()
         self._repeating_timer = None
         self._cache_lock = Lock()
+
+        request = context.makeRequest("field(value,timeStamp,alarm)")
+        self._sub = context.monitor(
+            pv_name, self._monitor_callback, request=request, notify_disconnect=True
+        )
 
         try:
             self._message_publisher = schema_publishers[schema]

--- a/forwarder/update_handlers/pva_update_handler.py
+++ b/forwarder/update_handlers/pva_update_handler.py
@@ -3,7 +3,7 @@ from p4p import Value
 from forwarder.kafka.kafka_producer import KafkaProducer
 from forwarder.application_logger import get_logger
 from typing import Optional, Tuple, Union
-from threading import Lock, Event
+from threading import Lock
 from forwarder.update_handlers.schema_publishers import schema_publishers
 from forwarder.repeat_timer import RepeatTimer, milliseconds_to_seconds
 from forwarder.epics_to_serialisable_types import (
@@ -51,7 +51,6 @@ class PVAUpdateHandler:
         self._pv_name = pv_name
         self._cached_update: Optional[Tuple[Value, int]] = None
         self._output_type = None
-        self._stop_timer_flag = Event()
         self._repeating_timer = None
         self._cache_lock = Lock()
 

--- a/forwarder/update_handlers/pva_update_handler.py
+++ b/forwarder/update_handlers/pva_update_handler.py
@@ -57,7 +57,10 @@ class PVAUpdateHandler:
 
         request = context.makeRequest("field(value,timeStamp,alarm)")
         self._sub = context.monitor(
-            pv_name, self._monitor_callback, request=request, notify_disconnect=True
+            self._pv_name,
+            self._monitor_callback,
+            request=request,
+            notify_disconnect=True,
         )
 
         try:


### PR DESCRIPTION
Can get an error warning about self._pv_name not being defined if monitor_callback happens before the value is defined.
Simple fix is to move the assignment up before trying to create the monitor.

<update>
Some of the other variables are used in the callback too, so I've moved them all up too.
