### PR TITLE
Implement NTTable to senv

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,8 +2,6 @@
 import ecdcpipeline.ContainerBuildNode
 import ecdcpipeline.PipelineBuilder
 
-project = "forwarder"
-
 container_build_nodes = [
   'centos7': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc8')
 ]
@@ -37,18 +35,15 @@ builders = pipeline_builder.createBuilders { container ->
   pipeline_builder.stage("${container.key}: Dependencies") {
     def conan_remote = "ess-dmsc-local"
     container.sh """
-      /opt/miniconda/bin/conda init bash
-      export PATH=/opt/miniconda/bin:$PATH
       python --version
-      python -m pip install --user -r ${project}/requirements-dev.txt
+      python -m pip install --user -r ${pipeline_builder.project}/requirements-dev.txt
     """
   } // stage
 
   pipeline_builder.stage("${container.key}: Formatting (black) ") {
     def conan_remote = "ess-dmsc-local"
     container.sh """
-      export PATH=/opt/miniconda/bin:$PATH
-      cd ${project}
+      cd ${pipeline_builder.project}
       python -m black --check .
     """
   } // stage
@@ -56,8 +51,7 @@ builders = pipeline_builder.createBuilders { container ->
   pipeline_builder.stage("${container.key}: Static Analysis (flake8) ") {
     def conan_remote = "ess-dmsc-local"
     container.sh """
-      export PATH=/opt/miniconda/bin:$PATH
-      cd ${project}
+      cd ${pipeline_builder.project}
       python -m flake8
     """
   } // stage
@@ -65,8 +59,7 @@ builders = pipeline_builder.createBuilders { container ->
   pipeline_builder.stage("${container.key}: Type Checking (mypy) ") {
     def conan_remote = "ess-dmsc-local"
     container.sh """
-      export PATH=/opt/miniconda/bin:$PATH
-      cd ${project}
+      cd ${pipeline_builder.project}
       python -m mypy .
     """
   } // stage
@@ -74,14 +67,13 @@ builders = pipeline_builder.createBuilders { container ->
   pipeline_builder.stage("${container.key}: Test") {
     def test_output = "TestResults.xml"
     container.sh """
-      export PATH=/opt/miniconda/bin:$PATH
       python --version
-      cd ${project}
+      cd ${pipeline_builder.project}
       python -m pytest --cov=forwarder --cov-report=xml --junitxml=${test_output}
     """
-    container.copyFrom("${project}/${test_output}", ".")
+    container.copyFrom("${pipeline_builder.project}/${test_output}", ".")
     xunit thresholds: [failed(unstableThreshold: '0')], tools: [JUnit(deleteOutputFiles: true, pattern: '*.xml', skipNoTestFiles: false, stopProcessingIfError: true)]
-    container.copyFrom("${project}/coverage.xml", ".")
+    container.copyFrom("${pipeline_builder.project}/coverage.xml", ".")
     withCredentials([string(credentialsId: 'forwarder-codecov-token', variable: 'TOKEN')]) {
     sh "curl -s https://codecov.io/bash | bash -s - -t ${TOKEN} -C ${scm_vars.GIT_COMMIT} -f coverage.xml"
     }
@@ -89,7 +81,7 @@ builders = pipeline_builder.createBuilders { container ->
 }  // createBuilders
 
 node {
-  dir("${project}") {
+  dir("${pipeline_builder.project}") {
     scm_vars = checkout scm
   }
 
@@ -111,14 +103,13 @@ def get_system_tests_pipeline() {
   return {
     node('system-test') {
       cleanWs()
-      dir("${project}") {
+      dir("${pipeline_builder.project}") {
         try {
           stage("System tests: Checkout") {
             checkout scm
           }  // stage
           stage("System tests: Install requirements") {
             sh """
-            export PATH=/opt/miniconda/bin:$PATH
             python --version
             python -m venv test_env
             source test_env/bin/activate

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,14 +110,14 @@ def get_system_tests_pipeline() {
           }  // stage
           stage("System tests: Install requirements") {
             sh """
-            python --version
-            python -m venv test_env
+            python3 --version
+            python3 -m venv test_env
             source test_env/bin/activate
-            which python
+            which python3
             pwd
-            pip install --upgrade pip
-            pip install -r requirements-dev.txt
-            pip install -r system_tests/requirements.txt
+            pip3 install --upgrade pip
+            pip3 install -r requirements-dev.txt
+            pip3 install -r system_tests/requirements.txt
             """
           }  // stage
           stage("System tests: Run") {
@@ -128,7 +128,7 @@ def get_system_tests_pipeline() {
               sh """
               source test_env/bin/activate
               cd system_tests/
-              python -m pytest -s --junitxml=./SystemTestsOutput.xml .
+              python3 -m pytest -s --junitxml=./SystemTestsOutput.xml .
               """
             }
           }  // stage

--- a/forwarder/configuration_store.py
+++ b/forwarder/configuration_store.py
@@ -24,15 +24,17 @@ class ConfigurationStore:
     def save_configuration(self, update_handlers: Dict):
         streams = []
         for channel, update_handler in update_handlers.items():
-            protocol_map = {EpicsProtocol.CA: Protocol.Protocol.CA,
-                            EpicsProtocol.FAKE: Protocol.Protocol.FAKE,
-                            EpicsProtocol.PVA: Protocol.Protocol.PVA}
+            protocol_map = {
+                EpicsProtocol.CA: Protocol.Protocol.CA,
+                EpicsProtocol.FAKE: Protocol.Protocol.FAKE,
+                EpicsProtocol.PVA: Protocol.Protocol.PVA,
+            }
             stream = StreamInfo(
                 channel.name,
                 channel.schema,
                 channel.output_topic,
                 protocol_map[channel.protocol],
-                )
+            )
 
             streams.append(stream)
         if streams:

--- a/forwarder/configuration_store.py
+++ b/forwarder/configuration_store.py
@@ -24,19 +24,14 @@ class ConfigurationStore:
     def save_configuration(self, update_handlers: Dict):
         streams = []
         for channel, update_handler in update_handlers.items():
-            if channel.protocol == EpicsProtocol.CA:
-                stream = StreamInfo(
-                    channel.name,
-                    channel.schema,
-                    channel.output_topic,
-                    Protocol.Protocol.CA,
-                )
-            else:
-                stream = StreamInfo(
-                    channel.name,
-                    channel.schema,
-                    channel.output_topic,
-                    Protocol.Protocol.PVA,
+            protocol_map = {EpicsProtocol.CA: Protocol.Protocol.CA,
+                            EpicsProtocol.FAKE: Protocol.Protocol.FAKE,
+                            EpicsProtocol.PVA: Protocol.Protocol.PVA}
+            stream = StreamInfo(
+                channel.name,
+                channel.schema,
+                channel.output_topic,
+                protocol_map[channel.protocol],
                 )
 
             streams.append(stream)

--- a/forwarder/kafka/kafka_helpers.py
+++ b/forwarder/kafka/kafka_helpers.py
@@ -52,7 +52,7 @@ def get_broker_and_topic_from_uri(uri: str) -> Tuple[str, str]:
 
 
 def _nanoseconds_to_milliseconds(time_ns: int) -> int:
-    return time_ns // 1_000_000
+    return int(time_ns) // 1_000_000
 
 
 _state_str_to_enum: Dict[Union[str, Exception], ConnectionStatusEventType] = {

--- a/forwarder/kafka/kafka_helpers.py
+++ b/forwarder/kafka/kafka_helpers.py
@@ -63,11 +63,7 @@ _state_str_to_enum: Dict[Union[str, Exception], ConnectionStatusEventType] = {
 
 
 def publish_connection_status_message(
-    producer: KafkaProducer,
-    topic: str,
-    pv_name: str,
-    timestamp_ns: int,
-    state: str,
+    producer: KafkaProducer, topic: str, pv_name: str, timestamp_ns: int, state: str
 ):
     producer.produce(
         topic,

--- a/forwarder/kafka/kafka_helpers.py
+++ b/forwarder/kafka/kafka_helpers.py
@@ -7,7 +7,6 @@ from streaming_data_types.fbschemas.epics_connection_info_ep00.EventType import 
     EventType as ConnectionStatusEventType,
 )
 
-
 from forwarder.utils import Counter
 
 from .kafka_producer import KafkaProducer

--- a/forwarder/kafka/kafka_helpers.py
+++ b/forwarder/kafka/kafka_helpers.py
@@ -1,15 +1,11 @@
 import uuid
 from typing import Dict, Optional, Tuple, Union
 
-import numpy as np
 from confluent_kafka import Consumer, Producer
 from streaming_data_types.epics_connection_info_ep00 import serialise_ep00
 from streaming_data_types.fbschemas.epics_connection_info_ep00.EventType import (
     EventType as ConnectionStatusEventType,
 )
-from streaming_data_types.fbschemas.logdata_f142.AlarmSeverity import AlarmSeverity
-from streaming_data_types.fbschemas.logdata_f142.AlarmStatus import AlarmStatus
-from streaming_data_types.logdata_f142 import serialise_f142
 
 
 from forwarder.utils import Counter
@@ -57,88 +53,6 @@ def get_broker_and_topic_from_uri(uri: str) -> Tuple[str, str]:
 
 def _nanoseconds_to_milliseconds(time_ns: int) -> int:
     return time_ns // 1_000_000
-
-
-# def publish_f142_message(
-#     producer: KafkaProducer,
-#     topic: str,
-#     data: np.ndarray,
-#     source_name: str,
-#     timestamp_ns: int,
-#     alarm_status: Optional[AlarmStatus] = None,
-#     alarm_severity: Optional[AlarmSeverity] = None,
-# ):
-#     """
-#     Publish an f142 message to a given topic.
-#     :param producer: Kafka producer to publish update with
-#     :param topic: Name of topic to publish to
-#     :param data: Value of the PV update
-#     :param source_name: Name of the PV
-#     :param timestamp_ns: Timestamp for value (nanoseconds after unix epoch)
-#     :param alarm_status:
-#     :param alarm_severity:
-#     """
-#     if alarm_status is None:
-#         f142_message = serialise_f142(
-#             value=data,
-#             source_name=source_name,
-#             timestamp_unix_ns=timestamp_ns,
-#         )
-#     else:
-#         f142_message = serialise_f142(
-#             value=data,
-#             source_name=source_name,
-#             timestamp_unix_ns=timestamp_ns,
-#             alarm_status=alarm_status,
-#             alarm_severity=alarm_severity,
-#         )
-#     producer.produce(
-#         topic,
-#         f142_message,
-#         key=source_name,
-#         timestamp_ms=_nanoseconds_to_milliseconds(timestamp_ns),
-#     )
-
-
-# def publish_tdct_message(
-#     producer: KafkaProducer,
-#     topic: str,
-#     data: np.ndarray,
-#     source_name: str,
-#     timestamp_ns: int,
-#     *unused,
-# ):
-#     """
-#     Publish an tdct message to a given topic.
-#     Currently the tdct does not contain alarms, but if it turns out to be the long term
-#     solution for getting chopper timestamps into Kafka we will likely add alarms to the
-#     schema
-#
-#     :param producer: Kafka producer to publish update with
-#     :param topic: Name of topic to publish to
-#     :param data: Value of the PV update
-#     :param source_name: Name of the PV
-#     :param timestamp_ns: Timestamp for value (nanoseconds after unix epoch)
-#     :param unused: Allow other args to be passed to match signature of other
-#         publish_*_message functions
-#     """
-#     # Timestamps in the data array are nanoseconds relative to the EPICS update timestamp
-#     # Convert to absolute (relative to unix epoch)
-#     unix_epoch_timestamps_ns = data + timestamp_ns
-#     producer.produce(
-#         topic,
-#         serialise_tdct(
-#             name=source_name, timestamps=unix_epoch_timestamps_ns.astype(np.uint64)
-#         ),
-#         key=source_name,
-#         timestamp_ms=_nanoseconds_to_milliseconds(timestamp_ns),
-#     )
-
-
-# def publish_nttable_senv_message(producer: KafkaProducer, topic: str, data: np.ndarray, source_name: str,
-#                                  timestamp_ns: int, *unused):
-#     print("Called it!")
-#     pass
 
 
 _state_str_to_enum: Dict[Union[str, Exception], ConnectionStatusEventType] = {

--- a/forwarder/kafka/kafka_helpers.py
+++ b/forwarder/kafka/kafka_helpers.py
@@ -10,7 +10,7 @@ from streaming_data_types.fbschemas.epics_connection_info_ep00.EventType import 
 from streaming_data_types.fbschemas.logdata_f142.AlarmSeverity import AlarmSeverity
 from streaming_data_types.fbschemas.logdata_f142.AlarmStatus import AlarmStatus
 from streaming_data_types.logdata_f142 import serialise_f142
-from streaming_data_types.timestamps_tdct import serialise_tdct
+
 
 from forwarder.utils import Counter
 
@@ -59,80 +59,86 @@ def _nanoseconds_to_milliseconds(time_ns: int) -> int:
     return time_ns // 1_000_000
 
 
-def publish_f142_message(
-    producer: KafkaProducer,
-    topic: str,
-    data: np.ndarray,
-    source_name: str,
-    timestamp_ns: int,
-    alarm_status: Optional[AlarmStatus] = None,
-    alarm_severity: Optional[AlarmSeverity] = None,
-):
-    """
-    Publish an f142 message to a given topic.
-    :param producer: Kafka producer to publish update with
-    :param topic: Name of topic to publish to
-    :param data: Value of the PV update
-    :param source_name: Name of the PV
-    :param timestamp_ns: Timestamp for value (nanoseconds after unix epoch)
-    :param alarm_status:
-    :param alarm_severity:
-    """
-    if alarm_status is None:
-        f142_message = serialise_f142(
-            value=data,
-            source_name=source_name,
-            timestamp_unix_ns=timestamp_ns,
-        )
-    else:
-        f142_message = serialise_f142(
-            value=data,
-            source_name=source_name,
-            timestamp_unix_ns=timestamp_ns,
-            alarm_status=alarm_status,
-            alarm_severity=alarm_severity,
-        )
-    producer.produce(
-        topic,
-        f142_message,
-        key=source_name,
-        timestamp_ms=_nanoseconds_to_milliseconds(timestamp_ns),
-    )
+# def publish_f142_message(
+#     producer: KafkaProducer,
+#     topic: str,
+#     data: np.ndarray,
+#     source_name: str,
+#     timestamp_ns: int,
+#     alarm_status: Optional[AlarmStatus] = None,
+#     alarm_severity: Optional[AlarmSeverity] = None,
+# ):
+#     """
+#     Publish an f142 message to a given topic.
+#     :param producer: Kafka producer to publish update with
+#     :param topic: Name of topic to publish to
+#     :param data: Value of the PV update
+#     :param source_name: Name of the PV
+#     :param timestamp_ns: Timestamp for value (nanoseconds after unix epoch)
+#     :param alarm_status:
+#     :param alarm_severity:
+#     """
+#     if alarm_status is None:
+#         f142_message = serialise_f142(
+#             value=data,
+#             source_name=source_name,
+#             timestamp_unix_ns=timestamp_ns,
+#         )
+#     else:
+#         f142_message = serialise_f142(
+#             value=data,
+#             source_name=source_name,
+#             timestamp_unix_ns=timestamp_ns,
+#             alarm_status=alarm_status,
+#             alarm_severity=alarm_severity,
+#         )
+#     producer.produce(
+#         topic,
+#         f142_message,
+#         key=source_name,
+#         timestamp_ms=_nanoseconds_to_milliseconds(timestamp_ns),
+#     )
 
 
-def publish_tdct_message(
-    producer: KafkaProducer,
-    topic: str,
-    data: np.ndarray,
-    source_name: str,
-    timestamp_ns: int,
-    *unused,
-):
-    """
-    Publish an tdct message to a given topic.
-    Currently the tdct does not contain alarms, but if it turns out to be the long term
-    solution for getting chopper timestamps into Kafka we will likely add alarms to the
-    schema
+# def publish_tdct_message(
+#     producer: KafkaProducer,
+#     topic: str,
+#     data: np.ndarray,
+#     source_name: str,
+#     timestamp_ns: int,
+#     *unused,
+# ):
+#     """
+#     Publish an tdct message to a given topic.
+#     Currently the tdct does not contain alarms, but if it turns out to be the long term
+#     solution for getting chopper timestamps into Kafka we will likely add alarms to the
+#     schema
+#
+#     :param producer: Kafka producer to publish update with
+#     :param topic: Name of topic to publish to
+#     :param data: Value of the PV update
+#     :param source_name: Name of the PV
+#     :param timestamp_ns: Timestamp for value (nanoseconds after unix epoch)
+#     :param unused: Allow other args to be passed to match signature of other
+#         publish_*_message functions
+#     """
+#     # Timestamps in the data array are nanoseconds relative to the EPICS update timestamp
+#     # Convert to absolute (relative to unix epoch)
+#     unix_epoch_timestamps_ns = data + timestamp_ns
+#     producer.produce(
+#         topic,
+#         serialise_tdct(
+#             name=source_name, timestamps=unix_epoch_timestamps_ns.astype(np.uint64)
+#         ),
+#         key=source_name,
+#         timestamp_ms=_nanoseconds_to_milliseconds(timestamp_ns),
+#     )
 
-    :param producer: Kafka producer to publish update with
-    :param topic: Name of topic to publish to
-    :param data: Value of the PV update
-    :param source_name: Name of the PV
-    :param timestamp_ns: Timestamp for value (nanoseconds after unix epoch)
-    :param unused: Allow other args to be passed to match signature of other
-        publish_*_message functions
-    """
-    # Timestamps in the data array are nanoseconds relative to the EPICS update timestamp
-    # Convert to absolute (relative to unix epoch)
-    unix_epoch_timestamps_ns = data + timestamp_ns
-    producer.produce(
-        topic,
-        serialise_tdct(
-            name=source_name, timestamps=unix_epoch_timestamps_ns.astype(np.uint64)
-        ),
-        key=source_name,
-        timestamp_ms=_nanoseconds_to_milliseconds(timestamp_ns),
-    )
+
+# def publish_nttable_senv_message(producer: KafkaProducer, topic: str, data: np.ndarray, source_name: str,
+#                                  timestamp_ns: int, *unused):
+#     print("Called it!")
+#     pass
 
 
 _state_str_to_enum: Dict[Union[str, Exception], ConnectionStatusEventType] = {

--- a/forwarder/kafka/kafka_producer.py
+++ b/forwarder/kafka/kafka_producer.py
@@ -33,11 +33,7 @@ class KafkaProducer:
         self._producer.flush(max_wait_to_publish_producer_queue)
 
     def produce(
-        self,
-        topic: str,
-        payload: bytes,
-        timestamp_ms: int,
-        key: Optional[str] = None,
+        self, topic: str, payload: bytes, timestamp_ms: int, key: Optional[str] = None
     ):
         def ack(err, _):
             if err:

--- a/forwarder/parse_config_update.py
+++ b/forwarder/parse_config_update.py
@@ -16,7 +16,7 @@ from streaming_data_types.forwarder_config_update_rf5k import (
 )
 
 from forwarder.application_logger import get_logger
-from forwarder.update_handlers.schema_publishers import schema_publishers
+from forwarder.update_handlers.schema_serialisers import schema_serialisers
 
 logger = get_logger()
 
@@ -119,7 +119,7 @@ def _parse_streams(
             )
             continue
 
-        if stream.schema and stream.schema not in schema_publishers.keys():
+        if stream.schema and stream.schema not in schema_serialisers.keys():
             logger.warning(
                 f'Unsupported schema type "{stream.schema}" specified for'
                 f"stream in configuration update message."

--- a/forwarder/update_handlers/base_update_handler.py
+++ b/forwarder/update_handlers/base_update_handler.py
@@ -1,7 +1,9 @@
-from forwarder.kafka.kafka_producer import KafkaProducer
-from forwarder.kafka.kafka_helpers import _nanoseconds_to_milliseconds
 from datetime import datetime, timedelta, timezone
+from typing import Union
+
 from forwarder.application_logger import get_logger
+from forwarder.kafka.kafka_helpers import _nanoseconds_to_milliseconds
+from forwarder.kafka.kafka_producer import KafkaProducer
 
 LOWER_AGE_LIMIT = timedelta(days=365.25)
 UPPER_AGE_LIMIT = timedelta(minutes=10)
@@ -17,7 +19,7 @@ class BaseUpdateHandler:
             year=1900, month=1, day=1, hour=0, minute=0, second=0, tzinfo=timezone.utc
         )
 
-    def _publish_message(self, message: bytes, timestamp_ns: int) -> None:
+    def _publish_message(self, message: bytes, timestamp_ns: Union[int, float]) -> None:
         message_datetime = datetime.fromtimestamp(timestamp_ns / 1e9, tz=timezone.utc)
         if message_datetime < self._last_timestamp:
             self._logger.error(
@@ -39,6 +41,6 @@ class BaseUpdateHandler:
         self._producer.produce(
             self._output_topic,
             message,
-            _nanoseconds_to_milliseconds(timestamp_ns),
+            _nanoseconds_to_milliseconds(int(timestamp_ns)),
             key=self._pv_name,
         )

--- a/forwarder/update_handlers/ca_update_handler.py
+++ b/forwarder/update_handlers/ca_update_handler.py
@@ -37,12 +37,11 @@ class CAUpdateHandler(BaseUpdateHandler):
         self._repeating_timer = None
         self._cache_lock = Lock()
 
-        try:
-            self._message_serialiser = schema_serialisers[schema](pv_name)
-        except KeyError:
+        if schema not in schema_serialisers:
             raise ValueError(
                 f"{schema} is not a recognised supported schema, use one of {list(schema_serialisers.keys())}"
             )
+        self._message_serialiser = schema_serialisers[schema](pv_name)
 
         (self._pv,) = context.get_pvs(
             pv_name, connection_state_callback=self._connection_state_callback

--- a/forwarder/update_handlers/ca_update_handler.py
+++ b/forwarder/update_handlers/ca_update_handler.py
@@ -109,7 +109,10 @@ class CAUpdateHandler:
 
     def _publish_message(self, message: bytes, timestamp_ns: int):
         self._producer.produce(
-            self._output_topic, message, _nanoseconds_to_milliseconds(timestamp_ns)
+            self._output_topic,
+            message,
+            _nanoseconds_to_milliseconds(timestamp_ns),
+            key=self._pv.name,
         )
 
     def stop(self):

--- a/forwarder/update_handlers/ca_update_handler.py
+++ b/forwarder/update_handlers/ca_update_handler.py
@@ -11,7 +11,7 @@ from forwarder.application_logger import get_logger
 from forwarder.kafka.kafka_helpers import (
     publish_connection_status_message,
     seconds_to_nanoseconds,
-    _nanoseconds_to_milliseconds
+    _nanoseconds_to_milliseconds,
 )
 from forwarder.kafka.kafka_producer import KafkaProducer
 from forwarder.repeat_timer import RepeatTimer, milliseconds_to_seconds
@@ -79,11 +79,15 @@ class CAUpdateHandler:
                 self._cached_update is None
                 or response.metadata.status != self._cached_update[0].metadata.status
             ):
-                self._publish_message(self._message_serialiser.serialise(response, serialise_alarm=True),
-                                      timestamp)
+                self._publish_message(
+                    self._message_serialiser.serialise(response, serialise_alarm=True),
+                    timestamp,
+                )
             else:
-                self._publish_message(self._message_serialiser.serialise(response, serialise_alarm=False),
-                                      timestamp)
+                self._publish_message(
+                    self._message_serialiser.serialise(response, serialise_alarm=False),
+                    timestamp,
+                )
             self._cached_update = (response, timestamp)
             if self._repeating_timer is not None:
                 self._repeating_timer.reset()
@@ -101,11 +105,17 @@ class CAUpdateHandler:
         with self._cache_lock:
             if self._cached_update is not None:
                 # Always include current alarm status in periodic update messages
-                self._publish_message(self._message_serialiser.serialise(self._cached_update[0], serialise_alarm=True),
-                                      self._cached_update[1])
+                self._publish_message(
+                    self._message_serialiser.serialise(
+                        self._cached_update[0], serialise_alarm=True
+                    ),
+                    self._cached_update[1],
+                )
 
     def _publish_message(self, message: bytes, timestamp_ns: int):
-        self._producer.produce(self._output_topic, message, _nanoseconds_to_milliseconds(timestamp_ns))
+        self._producer.produce(
+            self._output_topic, message, _nanoseconds_to_milliseconds(timestamp_ns)
+        )
 
     def stop(self):
         """

--- a/forwarder/update_handlers/ca_update_handler.py
+++ b/forwarder/update_handlers/ca_update_handler.py
@@ -1,6 +1,6 @@
 import time
 from threading import Lock
-from typing import Optional, Tuple
+from typing import Optional
 
 from caproto import ReadNotifyResponse
 from caproto.threading.client import PV

--- a/forwarder/update_handlers/ca_update_handler.py
+++ b/forwarder/update_handlers/ca_update_handler.py
@@ -12,8 +12,8 @@ from forwarder.kafka.kafka_helpers import (
 )
 from forwarder.kafka.kafka_producer import KafkaProducer
 from forwarder.repeat_timer import RepeatTimer, milliseconds_to_seconds
-from forwarder.update_handlers.schema_serialisers import schema_serialisers
 from forwarder.update_handlers.base_update_handler import BaseUpdateHandler
+from forwarder.update_handlers.schema_serialisers import schema_serialisers
 
 
 class CAUpdateHandler(BaseUpdateHandler):

--- a/forwarder/update_handlers/f142_serialiser.py
+++ b/forwarder/update_handlers/f142_serialiser.py
@@ -1,0 +1,55 @@
+from streaming_data_types.logdata_f142 import serialise_f142
+import numpy as np
+from typing import Union, Tuple
+import p4p
+from caproto import ReadNotifyResponse
+from forwarder.epics_to_serialisable_types import (
+    ca_alarm_status_to_f142,
+    epics_alarm_severity_to_f142,
+    numpy_type_from_caproto_type,
+    numpy_type_from_p4p_type,
+    pva_alarm_message_to_f142_alarm_status,
+)
+from forwarder.kafka.kafka_helpers import seconds_to_nanoseconds
+from streaming_data_types.fbschemas.logdata_f142.AlarmStatus import AlarmStatus
+
+
+def _get_alarm_status(response):
+    try:
+        alarm_status = pva_alarm_message_to_f142_alarm_status[response.alarm.message]
+    except KeyError:
+        alarm_status = AlarmStatus.UDF
+    return alarm_status
+
+
+def _extract_pva_data(update: p4p.Value):
+    if update.getID() == "epics:nt/NTEnum:1.0":
+        return update.value.index
+    data_type = numpy_type_from_p4p_type[update.type()["value"][-1]]
+    return np.squeeze(np.array(update.value)).astype(data_type)
+
+
+def _extract_ca_data(update: ReadNotifyResponse):
+    data_type = numpy_type_from_caproto_type[update.data_type]
+    return np.squeeze(np.array(update.data)).astype(data_type)
+
+
+class f142_Serialiser:
+    def __init__(self, source_name: str):
+        self._source_name = source_name
+
+    def serialise(self, update: Union[p4p.Value, ReadNotifyResponse], serialise_alarm: bool = True) -> Tuple[bytes, int]:
+        if isinstance(update, p4p.Value):
+            alarm = _get_alarm_status(update)
+            severity = epics_alarm_severity_to_f142[update.alarm.severity]
+            value = _extract_pva_data(update)
+            timestamp = (update.timeStamp.secondsPastEpoch * 1_000_000_000) + update.timeStamp.nanoseconds
+        elif isinstance(update, ReadNotifyResponse):
+            alarm = ca_alarm_status_to_f142[update.metadata.status]
+            severity = epics_alarm_severity_to_f142[update.metadata.severity]
+            timestamp = seconds_to_nanoseconds(update.metadata.timestamp)
+            value = _extract_ca_data(update)
+        extra_arguments = {}
+        if serialise_alarm:
+            extra_arguments = {"alarm_status": alarm, "alarm_severity": severity}
+        return serialise_f142(value, self._source_name, timestamp, **extra_arguments), timestamp

--- a/forwarder/update_handlers/f142_serialiser.py
+++ b/forwarder/update_handlers/f142_serialiser.py
@@ -1,8 +1,11 @@
-from streaming_data_types.logdata_f142 import serialise_f142
+from typing import Tuple, Union
+
 import numpy as np
-from typing import Union, Tuple
 import p4p
 from caproto import ReadNotifyResponse
+from streaming_data_types.fbschemas.logdata_f142.AlarmStatus import AlarmStatus
+from streaming_data_types.logdata_f142 import serialise_f142
+
 from forwarder.epics_to_serialisable_types import (
     ca_alarm_status_to_f142,
     epics_alarm_severity_to_f142,
@@ -11,7 +14,6 @@ from forwarder.epics_to_serialisable_types import (
     pva_alarm_message_to_f142_alarm_status,
 )
 from forwarder.kafka.kafka_helpers import seconds_to_nanoseconds
-from streaming_data_types.fbschemas.logdata_f142.AlarmStatus import AlarmStatus
 
 
 def _get_alarm_status(response):

--- a/forwarder/update_handlers/f142_serialiser.py
+++ b/forwarder/update_handlers/f142_serialiser.py
@@ -38,12 +38,16 @@ class f142_Serialiser:
     def __init__(self, source_name: str):
         self._source_name = source_name
 
-    def serialise(self, update: Union[p4p.Value, ReadNotifyResponse], serialise_alarm: bool = True) -> Tuple[bytes, int]:
+    def serialise(
+        self, update: Union[p4p.Value, ReadNotifyResponse], serialise_alarm: bool = True
+    ) -> Tuple[bytes, int]:
         if isinstance(update, p4p.Value):
             alarm = _get_alarm_status(update)
             severity = epics_alarm_severity_to_f142[update.alarm.severity]
             value = _extract_pva_data(update)
-            timestamp = (update.timeStamp.secondsPastEpoch * 1_000_000_000) + update.timeStamp.nanoseconds
+            timestamp = (
+                update.timeStamp.secondsPastEpoch * 1_000_000_000
+            ) + update.timeStamp.nanoseconds
         elif isinstance(update, ReadNotifyResponse):
             alarm = ca_alarm_status_to_f142[update.metadata.status]
             severity = epics_alarm_severity_to_f142[update.metadata.severity]
@@ -52,4 +56,7 @@ class f142_Serialiser:
         extra_arguments = {}
         if serialise_alarm:
             extra_arguments = {"alarm_status": alarm, "alarm_severity": severity}
-        return serialise_f142(value, self._source_name, timestamp, **extra_arguments), timestamp
+        return (
+            serialise_f142(value, self._source_name, timestamp, **extra_arguments),
+            timestamp,
+        )

--- a/forwarder/update_handlers/f142_serialiser.py
+++ b/forwarder/update_handlers/f142_serialiser.py
@@ -48,7 +48,7 @@ class f142_Serialiser:
             timestamp = (
                 update.timeStamp.secondsPastEpoch * 1_000_000_000
             ) + update.timeStamp.nanoseconds
-        elif isinstance(update, ReadNotifyResponse):
+        else:
             alarm = ca_alarm_status_to_f142[update.metadata.status]
             severity = epics_alarm_severity_to_f142[update.metadata.severity]
             timestamp = seconds_to_nanoseconds(update.metadata.timestamp)

--- a/forwarder/update_handlers/fake_update_handler.py
+++ b/forwarder/update_handlers/fake_update_handler.py
@@ -1,13 +1,12 @@
 from random import randint
 
 import numpy as np
+from p4p.nt import NTScalar
 
 from forwarder.kafka.kafka_producer import KafkaProducer
 from forwarder.repeat_timer import RepeatTimer, milliseconds_to_seconds
-from forwarder.update_handlers.schema_serialisers import schema_serialisers
 from forwarder.update_handlers.base_update_handler import BaseUpdateHandler
-
-from p4p.nt import NTScalar
+from forwarder.update_handlers.schema_serialisers import schema_serialisers
 
 
 class FakeUpdateHandler(BaseUpdateHandler):

--- a/forwarder/update_handlers/fake_update_handler.py
+++ b/forwarder/update_handlers/fake_update_handler.py
@@ -1,4 +1,3 @@
-import time
 from random import randint
 
 import numpy as np
@@ -50,8 +49,7 @@ class FakeUpdateHandler:
         else:
             # Otherwise 0D (scalar) is fine
             update = NTScalar("i").wrap(randint(0, 100))
-
-        self._publish_message(self._message_publisher.serialise(update), time.time_ns())
+        self._publish_message(*self._message_publisher.serialise(update))
 
     def _publish_message(self, message: bytes, timestamp_ns: int):
         self._producer.produce(

--- a/forwarder/update_handlers/fake_update_handler.py
+++ b/forwarder/update_handlers/fake_update_handler.py
@@ -55,7 +55,9 @@ class FakeUpdateHandler:
         self._publish_message(self._message_publisher.serialise(update), time.time_ns())
 
     def _publish_message(self, message: bytes, timestamp_ns: int):
-        self._producer.produce(self._output_topic, message, _nanoseconds_to_milliseconds(timestamp_ns))
+        self._producer.produce(
+            self._output_topic, message, _nanoseconds_to_milliseconds(timestamp_ns)
+        )
 
     def stop(self):
         """

--- a/forwarder/update_handlers/fake_update_handler.py
+++ b/forwarder/update_handlers/fake_update_handler.py
@@ -49,8 +49,7 @@ class FakeUpdateHandler:
             update = NTScalar("ai").wrap(data)
         else:
             # Otherwise 0D (scalar) is fine
-            data = randint(0, 100)
-            update = NTScalar("i").wrap(data)
+            update = NTScalar("i").wrap(randint(0, 100))
 
         self._publish_message(self._message_publisher.serialise(update), time.time_ns())
 

--- a/forwarder/update_handlers/nttable_senv_serialiser.py
+++ b/forwarder/update_handlers/nttable_senv_serialiser.py
@@ -1,0 +1,20 @@
+from streaming_data_types.sample_environment_senv import serialise_senv
+from typing import Union
+import p4p
+from caproto import ReadNotifyResponse
+
+class nttable_senv_Serialiser:
+    def __init__(self, source_name: str):
+        self._source_name = source_name
+        self._msg_counter = -1
+
+    def serialise(self, update: Union[p4p.Value, ReadNotifyResponse], **unused) -> bytes:
+        if isinstance(update, ReadNotifyResponse):
+            raise RuntimeError("nttable_senv_Serialiser is unable to process channel access data.")
+        # timestamp = (update.timeStamp.secondsPastEpoch * 1_000_000_000) + update.timeStamp.nanoseconds
+        self._msg_counter += 1
+        # return serialise_senv(
+        #     name=self._source_name, timestamps=unix_epoch_timestamps_ns.astype(np.uint64),
+        #     sequence_counter=self._msg_counter
+        # )
+        return b"aaaaaaaaaaaaaa"

--- a/forwarder/update_handlers/nttable_senv_serialiser.py
+++ b/forwarder/update_handlers/nttable_senv_serialiser.py
@@ -1,7 +1,7 @@
 from streaming_data_types.sample_environment_senv import serialise_senv
 from typing import Union, Tuple
 import p4p
-from caproto import ReadNotifyResponse
+from caproto import Message as CA_Message
 from datetime import datetime
 import numpy as np
 
@@ -12,9 +12,9 @@ class nttable_senv_Serialiser:
         self._msg_counter = -1
 
     def serialise(
-        self, update: Union[p4p.Value, ReadNotifyResponse], **unused
+        self, update: Union[p4p.Value, CA_Message], **unused
     ) -> Tuple[bytes, int]:
-        if isinstance(update, ReadNotifyResponse):
+        if isinstance(update, CA_Message):
             raise RuntimeError(
                 "nttable_senv_Serialiser is unable to process channel access data."
             )

--- a/forwarder/update_handlers/nttable_senv_serialiser.py
+++ b/forwarder/update_handlers/nttable_senv_serialiser.py
@@ -10,21 +10,37 @@ class nttable_senv_Serialiser:
         self._source_name = source_name
         self._msg_counter = -1
 
-    def serialise(self, update: Union[p4p.Value, ReadNotifyResponse], **unused) -> Tuple[bytes, int]:
+    def serialise(
+        self, update: Union[p4p.Value, ReadNotifyResponse], **unused
+    ) -> Tuple[bytes, int]:
         if isinstance(update, ReadNotifyResponse):
-            raise RuntimeError("nttable_senv_Serialiser is unable to process channel access data.")
+            raise RuntimeError(
+                "nttable_senv_Serialiser is unable to process channel access data."
+            )
         if update.getID() != "epics:nt/NTTable:1.0":
-            raise RuntimeError(f"Unable to process EPICS updates of type: \"{update.getID()}\".")
+            raise RuntimeError(
+                f'Unable to process EPICS updates of type: "{update.getID()}".'
+            )
         column_headers = update.value.keys()
         if "value" not in column_headers or "timestamp" not in column_headers:
-            raise RuntimeError(f"Unable to find required columns (\"value\", \"timestamp\") in NTTable. Found the columns {column_headers} instead.")
+            raise RuntimeError(
+                f'Unable to find required columns ("value", "timestamp") in NTTable. Found the columns {column_headers} instead.'
+            )
         values = update.value.value
         timestamps = update.value.timestamp
         self._msg_counter += 1
         origin_timestamp = timestamps[0]
         message_timestamp = datetime.fromtimestamp(origin_timestamp / 1e9)
         delta_time = timestamps[1] - timestamps[0]
-        return serialise_senv(
-            name=self._source_name, value_timestamps=timestamps, values=values, timestamp=message_timestamp,
-            message_counter=self._msg_counter, sample_ts_delta=delta_time, channel=0
-        ), origin_timestamp
+        return (
+            serialise_senv(
+                name=self._source_name,
+                value_timestamps=timestamps,
+                values=values,
+                timestamp=message_timestamp,
+                message_counter=self._msg_counter,
+                sample_ts_delta=delta_time,
+                channel=0,
+            ),
+            origin_timestamp,
+        )

--- a/forwarder/update_handlers/nttable_senv_serialiser.py
+++ b/forwarder/update_handlers/nttable_senv_serialiser.py
@@ -3,6 +3,7 @@ from typing import Union, Tuple
 import p4p
 from caproto import ReadNotifyResponse
 from datetime import datetime
+import numpy as np
 
 
 class nttable_senv_Serialiser:
@@ -28,6 +29,8 @@ class nttable_senv_Serialiser:
             )
         tables = update.value.items()
         values = tables[column_headers.index("value")][1]
+        if np.issubdtype(values.dtype, np.floating):
+            values = values.round().astype(np.int64)
         timestamps = tables[column_headers.index("timestamp")][1]
         self._msg_counter += 1
         origin_timestamp = timestamps[0]

--- a/forwarder/update_handlers/nttable_senv_serialiser.py
+++ b/forwarder/update_handlers/nttable_senv_serialiser.py
@@ -1,9 +1,10 @@
-from streaming_data_types.sample_environment_senv import serialise_senv
-from typing import Union, Tuple
+from datetime import datetime
+from typing import Tuple, Union
+
+import numpy as np
 import p4p
 from caproto import Message as CA_Message
-from datetime import datetime
-import numpy as np
+from streaming_data_types.sample_environment_senv import serialise_senv
 
 
 class nttable_senv_Serialiser:

--- a/forwarder/update_handlers/nttable_senv_serialiser.py
+++ b/forwarder/update_handlers/nttable_senv_serialiser.py
@@ -21,13 +21,14 @@ class nttable_senv_Serialiser:
             raise RuntimeError(
                 f'Unable to process EPICS updates of type: "{update.getID()}".'
             )
-        column_headers = update.value.keys()
+        column_headers = update.labels
         if "value" not in column_headers or "timestamp" not in column_headers:
             raise RuntimeError(
                 f'Unable to find required columns ("value", "timestamp") in NTTable. Found the columns {column_headers} instead.'
             )
-        values = update.value.value
-        timestamps = update.value.timestamp
+        tables = update.value.items()
+        values = tables[column_headers.index("value")][1]
+        timestamps = tables[column_headers.index("timestamp")][1]
         self._msg_counter += 1
         origin_timestamp = timestamps[0]
         message_timestamp = datetime.fromtimestamp(origin_timestamp / 1e9)

--- a/forwarder/update_handlers/nttable_senv_serialiser.py
+++ b/forwarder/update_handlers/nttable_senv_serialiser.py
@@ -1,20 +1,30 @@
 from streaming_data_types.sample_environment_senv import serialise_senv
-from typing import Union
+from typing import Union, Tuple
 import p4p
 from caproto import ReadNotifyResponse
+from datetime import datetime
+
 
 class nttable_senv_Serialiser:
     def __init__(self, source_name: str):
         self._source_name = source_name
         self._msg_counter = -1
 
-    def serialise(self, update: Union[p4p.Value, ReadNotifyResponse], **unused) -> bytes:
+    def serialise(self, update: Union[p4p.Value, ReadNotifyResponse], **unused) -> Tuple[bytes, int]:
         if isinstance(update, ReadNotifyResponse):
             raise RuntimeError("nttable_senv_Serialiser is unable to process channel access data.")
-        # timestamp = (update.timeStamp.secondsPastEpoch * 1_000_000_000) + update.timeStamp.nanoseconds
+        if update.getID() != "epics:nt/NTTable:1.0":
+            raise RuntimeError(f"Unable to process EPICS updates of type: \"{update.getID()}\".")
+        column_headers = update.value.keys()
+        if "value" not in column_headers or "timestamp" not in column_headers:
+            raise RuntimeError(f"Unable to find required columns (\"value\", \"timestamp\") in NTTable. Found the columns {column_headers} instead.")
+        values = update.value.value
+        timestamps = update.value.timestamp
         self._msg_counter += 1
-        # return serialise_senv(
-        #     name=self._source_name, timestamps=unix_epoch_timestamps_ns.astype(np.uint64),
-        #     sequence_counter=self._msg_counter
-        # )
-        return b"aaaaaaaaaaaaaa"
+        origin_timestamp = timestamps[0]
+        message_timestamp = datetime.fromtimestamp(origin_timestamp / 1e9)
+        delta_time = timestamps[1] - timestamps[0]
+        return serialise_senv(
+            name=self._source_name, value_timestamps=timestamps, values=values, timestamp=message_timestamp,
+            message_counter=self._msg_counter, sample_ts_delta=delta_time, channel=0
+        ), origin_timestamp

--- a/forwarder/update_handlers/pva_update_handler.py
+++ b/forwarder/update_handlers/pva_update_handler.py
@@ -1,20 +1,13 @@
 import time
 from threading import Lock
-from typing import Any, Optional, Tuple, Union
+from typing import Optional, Tuple, Union
 
-import numpy as np
 from p4p import Value
 from p4p.client.thread import Cancelled
 from p4p.client.thread import Context as PVAContext
 from p4p.client.thread import Disconnected, RemoteError
-from streaming_data_types.fbschemas.logdata_f142.AlarmStatus import AlarmStatus
 
 from forwarder.application_logger import get_logger
-from forwarder.epics_to_serialisable_types import (
-    epics_alarm_severity_to_f142,
-    numpy_type_from_p4p_type,
-    pva_alarm_message_to_f142_alarm_status,
-)
 from forwarder.kafka.kafka_helpers import (
     publish_connection_status_message,
     seconds_to_nanoseconds,
@@ -23,14 +16,6 @@ from forwarder.kafka.kafka_helpers import (
 from forwarder.kafka.kafka_producer import KafkaProducer
 from forwarder.repeat_timer import RepeatTimer, milliseconds_to_seconds
 from forwarder.update_handlers.schema_serialisers import schema_serialisers
-
-
-# def _get_alarm_status(response):
-#     try:
-#         alarm_status = pva_alarm_message_to_f142_alarm_status[response.alarm.message]
-#     except Exception:
-#         alarm_status = AlarmStatus.UDF
-#     return alarm_status
 
 
 class PVAUpdateHandler:
@@ -54,7 +39,6 @@ class PVAUpdateHandler:
         self._output_topic = output_topic
         self._pv_name = pv_name
         self._cached_update: Optional[Tuple[Value, int]] = None
-        # self._output_type: Any = None
         self._repeating_timer = None
         self._cache_lock = Lock()
 
@@ -109,8 +93,6 @@ class PVAUpdateHandler:
         timestamp = (
             response.timeStamp.secondsPastEpoch * 1_000_000_000
         ) + response.timeStamp.nanoseconds
-        # if self._output_type is None:
-        #     self._try_to_determine_type(response)
 
         with self._cache_lock:
             # If this is the first update or the alarm status has changed, then
@@ -120,74 +102,17 @@ class PVAUpdateHandler:
                 or response.alarm.message != self._cached_update[0].alarm.message
             ):
                 self._publish_message(self._message_serialiser.serialise(response, serialise_alarm=True), timestamp)
-                # self._message_publisher(
-                #     self._producer,
-                #     self._output_topic,
-                #     np.squeeze(np.array(self._get_value(response))).astype(
-                #         self._output_type
-                #     ),
-                #     self._pv_name,
-                #     timestamp,
-                #     _get_alarm_status(response),
-                #     epics_alarm_severity_to_f142[response.alarm.severity],
-                # )
             else:
                 self._publish_message(self._message_serialiser.serialise(response, serialise_alarm=False), timestamp)
-                # self._message_publisher(
-                #     self._producer,
-                #     self._output_topic,
-                #     np.squeeze(np.array(self._get_value(response))).astype(
-                #         self._output_type
-                #     ),
-                #     self._pv_name,
-                #     timestamp,
-                # )
             self._cached_update = (response, timestamp)
             if self._repeating_timer is not None:
                 self._repeating_timer.reset()
-
-    # def _try_to_determine_type(self, response):
-    #     try:
-    #         is_enum = False
-    #         try:
-    #             if response.type()["value"].getID() == "enum_t":
-    #                 is_enum = True
-    #         except AttributeError:
-    #             # Attribute error raised because getID doesn't exist for scalar and
-    #             # scalar-array types.
-    #             # Array output types are prefixed by "a", we don't need this.
-    #             self._output_type = numpy_type_from_p4p_type[
-    #                 response.type()["value"][-1]
-    #             ]
-    #
-    #         if is_enum:
-    #             # We forward enum as string
-    #             self._output_type = np.unicode_
-    #             self._get_value = lambda resp: resp.value.choices[resp.value.index]
-    #         else:
-    #             self._get_value = lambda resp: resp.value
-    #     except KeyError:
-    #         self._logger.error(
-    #             f"Don't know what numpy dtype to use for channel type {type(response)}"
-    #         )
 
     def publish_cached_update(self):
         with self._cache_lock:
             if self._cached_update is not None:
                 # Always include current alarm status in periodic update messages
                 self._publish_message(self._message_serialiser.serialise(self._cached_update[0], serialise_alarm=True), self._cached_update[1])
-                # self._publish_message()
-                # self._message_publisher(
-                #     self._producer,
-                #     self._output_topic,
-                #     np.squeeze(
-                #         np.array(self._get_value(self._cached_update[0]))
-                #     ).astype(self._output_type),
-                #     self._pv_name,
-                #     self._cached_update[1],
-                #     _get_alarm_status(self._cached_update[0]),
-                #     epics_alarm_severity_to_f142[self._cached_update[0].alarm.severity],
-                # )
 
     def _publish_message(self, message: bytes, timestamp_ns: int):
         self._producer.produce(self._output_topic, message, _nanoseconds_to_milliseconds(timestamp_ns))

--- a/forwarder/update_handlers/pva_update_handler.py
+++ b/forwarder/update_handlers/pva_update_handler.py
@@ -1,6 +1,6 @@
 import time
 from threading import Lock
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 
 from p4p import Value
 from p4p.client.thread import Cancelled

--- a/forwarder/update_handlers/pva_update_handler.py
+++ b/forwarder/update_handlers/pva_update_handler.py
@@ -18,18 +18,19 @@ from forwarder.epics_to_serialisable_types import (
 from forwarder.kafka.kafka_helpers import (
     publish_connection_status_message,
     seconds_to_nanoseconds,
+    _nanoseconds_to_milliseconds
 )
 from forwarder.kafka.kafka_producer import KafkaProducer
 from forwarder.repeat_timer import RepeatTimer, milliseconds_to_seconds
-from forwarder.update_handlers.schema_publishers import schema_publishers
+from forwarder.update_handlers.schema_serialisers import schema_serialisers
 
 
-def _get_alarm_status(response):
-    try:
-        alarm_status = pva_alarm_message_to_f142_alarm_status[response.alarm.message]
-    except Exception:
-        alarm_status = AlarmStatus.UDF
-    return alarm_status
+# def _get_alarm_status(response):
+#     try:
+#         alarm_status = pva_alarm_message_to_f142_alarm_status[response.alarm.message]
+#     except Exception:
+#         alarm_status = AlarmStatus.UDF
+#     return alarm_status
 
 
 class PVAUpdateHandler:
@@ -53,18 +54,18 @@ class PVAUpdateHandler:
         self._output_topic = output_topic
         self._pv_name = pv_name
         self._cached_update: Optional[Tuple[Value, int]] = None
-        self._output_type: Any = None
+        # self._output_type: Any = None
         self._repeating_timer = None
         self._cache_lock = Lock()
 
         try:
-            self._message_publisher = schema_publishers[schema]
+            self._message_serialiser = schema_serialisers[schema](self._pv_name)
         except KeyError:
             raise ValueError(
-                f"{schema} is not a recognised supported schema, use one of {list(schema_publishers.keys())}"
+                f"{schema} is not a recognised supported schema, use one of {list(schema_serialisers.keys())}"
             )
 
-        request = context.makeRequest("field(value,timeStamp,alarm)")
+        request = context.makeRequest("field()")
         self._sub = context.monitor(
             self._pv_name,
             self._monitor_callback,
@@ -108,8 +109,8 @@ class PVAUpdateHandler:
         timestamp = (
             response.timeStamp.secondsPastEpoch * 1_000_000_000
         ) + response.timeStamp.nanoseconds
-        if self._output_type is None:
-            self._try_to_determine_type(response)
+        # if self._output_type is None:
+        #     self._try_to_determine_type(response)
 
         with self._cache_lock:
             # If this is the first update or the alarm status has changed, then
@@ -118,71 +119,78 @@ class PVAUpdateHandler:
                 self._cached_update is None
                 or response.alarm.message != self._cached_update[0].alarm.message
             ):
-                self._message_publisher(
-                    self._producer,
-                    self._output_topic,
-                    np.squeeze(np.array(self._get_value(response))).astype(
-                        self._output_type
-                    ),
-                    self._pv_name,
-                    timestamp,
-                    _get_alarm_status(response),
-                    epics_alarm_severity_to_f142[response.alarm.severity],
-                )
+                self._publish_message(self._message_serialiser.serialise(response, serialise_alarm=True), timestamp)
+                # self._message_publisher(
+                #     self._producer,
+                #     self._output_topic,
+                #     np.squeeze(np.array(self._get_value(response))).astype(
+                #         self._output_type
+                #     ),
+                #     self._pv_name,
+                #     timestamp,
+                #     _get_alarm_status(response),
+                #     epics_alarm_severity_to_f142[response.alarm.severity],
+                # )
             else:
-                self._message_publisher(
-                    self._producer,
-                    self._output_topic,
-                    np.squeeze(np.array(self._get_value(response))).astype(
-                        self._output_type
-                    ),
-                    self._pv_name,
-                    timestamp,
-                )
+                self._publish_message(self._message_serialiser.serialise(response, serialise_alarm=False), timestamp)
+                # self._message_publisher(
+                #     self._producer,
+                #     self._output_topic,
+                #     np.squeeze(np.array(self._get_value(response))).astype(
+                #         self._output_type
+                #     ),
+                #     self._pv_name,
+                #     timestamp,
+                # )
             self._cached_update = (response, timestamp)
             if self._repeating_timer is not None:
                 self._repeating_timer.reset()
 
-    def _try_to_determine_type(self, response):
-        try:
-            is_enum = False
-            try:
-                if response.type()["value"].getID() == "enum_t":
-                    is_enum = True
-            except AttributeError:
-                # Attribute error raised because getID doesn't exist for scalar and
-                # scalar-array types.
-                # Array output types are prefixed by "a", we don't need this.
-                self._output_type = numpy_type_from_p4p_type[
-                    response.type()["value"][-1]
-                ]
-
-            if is_enum:
-                # We forward enum as string
-                self._output_type = np.unicode_
-                self._get_value = lambda resp: resp.value.choices[resp.value.index]
-            else:
-                self._get_value = lambda resp: resp.value
-        except KeyError:
-            self._logger.error(
-                f"Don't know what numpy dtype to use for channel type {type(response)}"
-            )
+    # def _try_to_determine_type(self, response):
+    #     try:
+    #         is_enum = False
+    #         try:
+    #             if response.type()["value"].getID() == "enum_t":
+    #                 is_enum = True
+    #         except AttributeError:
+    #             # Attribute error raised because getID doesn't exist for scalar and
+    #             # scalar-array types.
+    #             # Array output types are prefixed by "a", we don't need this.
+    #             self._output_type = numpy_type_from_p4p_type[
+    #                 response.type()["value"][-1]
+    #             ]
+    #
+    #         if is_enum:
+    #             # We forward enum as string
+    #             self._output_type = np.unicode_
+    #             self._get_value = lambda resp: resp.value.choices[resp.value.index]
+    #         else:
+    #             self._get_value = lambda resp: resp.value
+    #     except KeyError:
+    #         self._logger.error(
+    #             f"Don't know what numpy dtype to use for channel type {type(response)}"
+    #         )
 
     def publish_cached_update(self):
         with self._cache_lock:
             if self._cached_update is not None:
                 # Always include current alarm status in periodic update messages
-                self._message_publisher(
-                    self._producer,
-                    self._output_topic,
-                    np.squeeze(
-                        np.array(self._get_value(self._cached_update[0]))
-                    ).astype(self._output_type),
-                    self._pv_name,
-                    self._cached_update[1],
-                    _get_alarm_status(self._cached_update[0]),
-                    epics_alarm_severity_to_f142[self._cached_update[0].alarm.severity],
-                )
+                self._publish_message(self._message_serialiser.serialise(self._cached_update[0], serialise_alarm=True), self._cached_update[1])
+                # self._publish_message()
+                # self._message_publisher(
+                #     self._producer,
+                #     self._output_topic,
+                #     np.squeeze(
+                #         np.array(self._get_value(self._cached_update[0]))
+                #     ).astype(self._output_type),
+                #     self._pv_name,
+                #     self._cached_update[1],
+                #     _get_alarm_status(self._cached_update[0]),
+                #     epics_alarm_severity_to_f142[self._cached_update[0].alarm.severity],
+                # )
+
+    def _publish_message(self, message: bytes, timestamp_ns: int):
+        self._producer.produce(self._output_topic, message, _nanoseconds_to_milliseconds(timestamp_ns))
 
     def stop(self):
         """

--- a/forwarder/update_handlers/pva_update_handler.py
+++ b/forwarder/update_handlers/pva_update_handler.py
@@ -13,8 +13,8 @@ from forwarder.kafka.kafka_helpers import (
 )
 from forwarder.kafka.kafka_producer import KafkaProducer
 from forwarder.repeat_timer import RepeatTimer, milliseconds_to_seconds
-from forwarder.update_handlers.schema_serialisers import schema_serialisers
 from forwarder.update_handlers.base_update_handler import BaseUpdateHandler
+from forwarder.update_handlers.schema_serialisers import schema_serialisers
 
 
 class PVAUpdateHandler(BaseUpdateHandler):

--- a/forwarder/update_handlers/pva_update_handler.py
+++ b/forwarder/update_handlers/pva_update_handler.py
@@ -120,7 +120,10 @@ class PVAUpdateHandler:
 
     def _publish_message(self, message: bytes, timestamp_ns: int):
         self._producer.produce(
-            self._output_topic, message, _nanoseconds_to_milliseconds(timestamp_ns)
+            self._output_topic,
+            message,
+            _nanoseconds_to_milliseconds(timestamp_ns),
+            key=self._pv_name,
         )
 
     def stop(self):

--- a/forwarder/update_handlers/pva_update_handler.py
+++ b/forwarder/update_handlers/pva_update_handler.py
@@ -11,7 +11,7 @@ from forwarder.application_logger import get_logger
 from forwarder.kafka.kafka_helpers import (
     publish_connection_status_message,
     seconds_to_nanoseconds,
-    _nanoseconds_to_milliseconds
+    _nanoseconds_to_milliseconds,
 )
 from forwarder.kafka.kafka_producer import KafkaProducer
 from forwarder.repeat_timer import RepeatTimer, milliseconds_to_seconds
@@ -101,9 +101,15 @@ class PVAUpdateHandler:
                 self._cached_update is None
                 or response.alarm.message != self._cached_update[0].alarm.message
             ):
-                self._publish_message(self._message_serialiser.serialise(response, serialise_alarm=True), timestamp)
+                self._publish_message(
+                    self._message_serialiser.serialise(response, serialise_alarm=True),
+                    timestamp,
+                )
             else:
-                self._publish_message(self._message_serialiser.serialise(response, serialise_alarm=False), timestamp)
+                self._publish_message(
+                    self._message_serialiser.serialise(response, serialise_alarm=False),
+                    timestamp,
+                )
             self._cached_update = (response, timestamp)
             if self._repeating_timer is not None:
                 self._repeating_timer.reset()
@@ -112,10 +118,17 @@ class PVAUpdateHandler:
         with self._cache_lock:
             if self._cached_update is not None:
                 # Always include current alarm status in periodic update messages
-                self._publish_message(self._message_serialiser.serialise(self._cached_update[0], serialise_alarm=True), self._cached_update[1])
+                self._publish_message(
+                    self._message_serialiser.serialise(
+                        self._cached_update[0], serialise_alarm=True
+                    ),
+                    self._cached_update[1],
+                )
 
     def _publish_message(self, message: bytes, timestamp_ns: int):
-        self._producer.produce(self._output_topic, message, _nanoseconds_to_milliseconds(timestamp_ns))
+        self._producer.produce(
+            self._output_topic, message, _nanoseconds_to_milliseconds(timestamp_ns)
+        )
 
     def stop(self):
         """

--- a/forwarder/update_handlers/schema_publishers.py
+++ b/forwarder/update_handlers/schema_publishers.py
@@ -1,8 +1,0 @@
-from typing import Callable, Dict
-
-from forwarder.kafka.kafka_helpers import publish_f142_message, publish_tdct_message
-
-schema_publishers: Dict[str, Callable] = {
-    "f142": publish_f142_message,
-    "tdct": publish_tdct_message,
-}

--- a/forwarder/update_handlers/schema_serialisers.py
+++ b/forwarder/update_handlers/schema_serialisers.py
@@ -1,8 +1,8 @@
 from typing import Callable, Dict
 
-from forwarder.update_handlers.tdct_serialiser import tdct_Serialiser
-from forwarder.update_handlers.nttable_senv_serialiser import nttable_senv_Serialiser
 from forwarder.update_handlers.f142_serialiser import f142_Serialiser
+from forwarder.update_handlers.nttable_senv_serialiser import nttable_senv_Serialiser
+from forwarder.update_handlers.tdct_serialiser import tdct_Serialiser
 
 schema_serialisers: Dict[str, Callable] = {
     "f142": f142_Serialiser,

--- a/forwarder/update_handlers/schema_serialisers.py
+++ b/forwarder/update_handlers/schema_serialisers.py
@@ -1,0 +1,11 @@
+from typing import Callable, Dict
+
+from forwarder.update_handlers.tdct_serialiser import tdct_Serialiser
+from forwarder.update_handlers.nttable_senv_serialiser import nttable_senv_Serialiser
+from forwarder.update_handlers.f142_serialiser import f142_Serialiser
+
+schema_serialisers: Dict[str, Callable] = {
+    "f142": f142_Serialiser,
+    "tdct": tdct_Serialiser,
+    "nttable_senv": nttable_senv_Serialiser,
+}

--- a/forwarder/update_handlers/tdct_serialiser.py
+++ b/forwarder/update_handlers/tdct_serialiser.py
@@ -19,6 +19,7 @@ def _extract_ca_data(update: ReadNotifyResponse):
     data_type = numpy_type_from_caproto_type[update.data_type]
     return np.squeeze(np.array(update.data)).astype(data_type)
 
+
 class tdct_Serialiser:
     def __init__(self, source_name: str):
         self._source_name = source_name

--- a/forwarder/update_handlers/tdct_serialiser.py
+++ b/forwarder/update_handlers/tdct_serialiser.py
@@ -1,0 +1,40 @@
+from streaming_data_types.timestamps_tdct import serialise_tdct
+import p4p
+from typing import Union, Tuple
+from caproto import ReadNotifyResponse
+import numpy as np
+from forwarder.epics_to_serialisable_types import numpy_type_from_p4p_type, numpy_type_from_caproto_type
+from forwarder.kafka.kafka_helpers import seconds_to_nanoseconds
+
+
+def _extract_pva_data(update: p4p.Value):
+    allowed_types = ["epics:nt/NTScalar:1.0", "epics:nt/NTScalarArray:1.0"]
+    if update.getID() not in allowed_types:
+        raise RuntimeError(f"Unable to extract TDC data from EPICS type: \"{update.getID()}\"")
+    data_type = numpy_type_from_p4p_type[update.type()["value"][-1]]
+    return np.squeeze(np.array(update.value)).astype(data_type)
+
+
+def _extract_ca_data(update: ReadNotifyResponse):
+    data_type = numpy_type_from_caproto_type[update.data_type]
+    return np.squeeze(np.array(update.data)).astype(data_type)
+
+class tdct_Serialiser:
+    def __init__(self, source_name: str):
+        self._source_name = source_name
+        self._msg_counter = -1
+
+    def serialise(self, update: Union[p4p.Value, ReadNotifyResponse], **unused) -> Tuple[bytes, int]:
+        if isinstance(update, p4p.Value):
+            origin_time = (update.timeStamp.secondsPastEpoch * 1_000_000_000) + update.timeStamp.nanoseconds
+            value_arr = _extract_pva_data(update)
+        elif isinstance(update, ReadNotifyResponse):
+            origin_time = seconds_to_nanoseconds(update.metadata.timestamp)
+            value_arr = _extract_ca_data(update)
+        timestamps = value_arr + origin_time
+        self._msg_counter += 1
+        return serialise_tdct(
+            name=self._source_name, timestamps=timestamps.astype(np.uint64),
+            sequence_counter=self._msg_counter
+        ), origin_time
+

--- a/forwarder/update_handlers/tdct_serialiser.py
+++ b/forwarder/update_handlers/tdct_serialiser.py
@@ -3,14 +3,19 @@ import p4p
 from typing import Union, Tuple
 from caproto import ReadNotifyResponse
 import numpy as np
-from forwarder.epics_to_serialisable_types import numpy_type_from_p4p_type, numpy_type_from_caproto_type
+from forwarder.epics_to_serialisable_types import (
+    numpy_type_from_p4p_type,
+    numpy_type_from_caproto_type,
+)
 from forwarder.kafka.kafka_helpers import seconds_to_nanoseconds
 
 
 def _extract_pva_data(update: p4p.Value):
     allowed_types = ["epics:nt/NTScalar:1.0", "epics:nt/NTScalarArray:1.0"]
     if update.getID() not in allowed_types:
-        raise RuntimeError(f"Unable to extract TDC data from EPICS type: \"{update.getID()}\"")
+        raise RuntimeError(
+            f'Unable to extract TDC data from EPICS type: "{update.getID()}"'
+        )
     data_type = numpy_type_from_p4p_type[update.type()["value"][-1]]
     return np.squeeze(np.array(update.value)).astype(data_type)
 
@@ -25,17 +30,24 @@ class tdct_Serialiser:
         self._source_name = source_name
         self._msg_counter = -1
 
-    def serialise(self, update: Union[p4p.Value, ReadNotifyResponse], **unused) -> Tuple[bytes, int]:
+    def serialise(
+        self, update: Union[p4p.Value, ReadNotifyResponse], **unused
+    ) -> Tuple[bytes, int]:
         if isinstance(update, p4p.Value):
-            origin_time = (update.timeStamp.secondsPastEpoch * 1_000_000_000) + update.timeStamp.nanoseconds
+            origin_time = (
+                update.timeStamp.secondsPastEpoch * 1_000_000_000
+            ) + update.timeStamp.nanoseconds
             value_arr = _extract_pva_data(update)
         elif isinstance(update, ReadNotifyResponse):
             origin_time = seconds_to_nanoseconds(update.metadata.timestamp)
             value_arr = _extract_ca_data(update)
         timestamps = value_arr + origin_time
         self._msg_counter += 1
-        return serialise_tdct(
-            name=self._source_name, timestamps=timestamps.astype(np.uint64),
-            sequence_counter=self._msg_counter
-        ), origin_time
-
+        return (
+            serialise_tdct(
+                name=self._source_name,
+                timestamps=timestamps.astype(np.uint64),
+                sequence_counter=self._msg_counter,
+            ),
+            origin_time,
+        )

--- a/forwarder/update_handlers/tdct_serialiser.py
+++ b/forwarder/update_handlers/tdct_serialiser.py
@@ -1,11 +1,13 @@
-from streaming_data_types.timestamps_tdct import serialise_tdct
-import p4p
-from typing import Union, Tuple
-from caproto import Message as CA_Message
+from typing import Tuple, Union
+
 import numpy as np
+import p4p
+from caproto import Message as CA_Message
+from streaming_data_types.timestamps_tdct import serialise_tdct
+
 from forwarder.epics_to_serialisable_types import (
-    numpy_type_from_p4p_type,
     numpy_type_from_caproto_type,
+    numpy_type_from_p4p_type,
 )
 from forwarder.kafka.kafka_helpers import seconds_to_nanoseconds
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ graphyte == 1.6.0
 numpy == 1.20.1
 attrs == 20.3.0
 ConfigArgParse == 1.3
-ess-streaming-data-types == 0.10.0
+ess-streaming-data-types == 0.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ confluent_kafka == 1.7.0
 flatbuffers == 1.12
 graypy == 2.1.0
 graphyte == 1.7.0
-numpy == 1.21.2
+numpy >= 1.19
 attrs == 21.2.0
 ConfigArgParse == 1.5.2
 ess-streaming-data-types == 0.14.0

--- a/system_tests/test_forwarding.py
+++ b/system_tests/test_forwarding.py
@@ -34,8 +34,6 @@ from .helpers.PVs import (
 )
 
 CONFIG_TOPIC = "TEST_forwarderConfig"
-INITIAL_STRING_VALUE = "test"
-INITIAL_ENUM_VALUE = "INIT"
 INITIAL_LONG_VALUE = 0
 INITIAL_DOUBLE_VALUE = 0.0
 INITIAL_FLOATARRAY_VALUE = (1.1, 2.2, 3.3, 4.4, 5.5)
@@ -51,9 +49,7 @@ def setup_and_teardown_function(request):
         PVDOUBLE: INITIAL_DOUBLE_VALUE,
         # We have to use this as the second parameter for caput gets parsed as empty so does not change the value of
         # the PV
-        PVSTR: INITIAL_STRING_VALUE,
         PVLONG: INITIAL_LONG_VALUE,
-        PVENUM: np.array([INITIAL_ENUM_VALUE]).astype(np.string_),
         PVDOUBLE_WITH_ALARM_THRESHOLDS: INITIAL_DOUBLE_VALUE,
         PVFLOATARRAY: INITIAL_FLOATARRAY_VALUE,
     }
@@ -108,11 +104,10 @@ def test_forwarding_of_various_pv_types(epics_protocol, docker_compose_forwardin
     cons = create_consumer()
     cons.subscribe([data_topic])
 
-    forwarding_enum(cons, prod)
     consumer_seek_to_end_of_topic(cons, data_topic)
     forwarding_floatarray(cons, prod)
     consumer_seek_to_end_of_topic(cons, data_topic)
-    forwarding_string_and_long(cons, prod)
+    forwarding_long(cons, prod)
     consumer_seek_to_end_of_topic(cons, data_topic)
     forwarding_double_with_alarm(cons, prod)
 
@@ -173,22 +168,6 @@ def forwarding_double_with_alarm(consumer: Consumer, producer: ProducerWrapper):
     )
 
 
-def forwarding_enum(consumer: Consumer, producer: ProducerWrapper):
-    pvs = [PVENUM]
-    producer.add_config(pvs)
-    # Wait for config change to be picked up
-    sleep(5)
-    new_enum_value = "START"
-    change_pv_value(PVENUM, np.array([new_enum_value]).astype(np.string_))
-    # Wait for forwarder to forward PV update into Kafka
-    sleep(5)
-    first_msg, _ = poll_for_valid_message(consumer)
-    check_expected_value(first_msg, PVENUM, INITIAL_ENUM_VALUE)
-    second_msg, _ = poll_for_valid_message(consumer)
-    check_expected_value(second_msg, PVENUM, new_enum_value)
-    producer.remove_config(pvs)
-
-
 def forwarding_floatarray(consumer: Consumer, producer: ProducerWrapper):
     pvs = [PVFLOATARRAY]
     producer.add_config(pvs)
@@ -205,22 +184,19 @@ def forwarding_floatarray(consumer: Consumer, producer: ProducerWrapper):
     producer.remove_config(pvs)
 
 
-def forwarding_string_and_long(consumer: Consumer, producer: ProducerWrapper):
-    pvs = [PVSTR, PVLONG]
+def forwarding_long(consumer: Consumer, producer: ProducerWrapper):
+    pvs = [PVLONG, ]
     producer.add_config(pvs)
     # Wait for config to be pushed
     sleep(5)
-    initial_string_value = INITIAL_STRING_VALUE
     initial_long_value = INITIAL_LONG_VALUE
     # Wait for forwarder to forward PV update into Kafka
     sleep(5)
     expected_values = {
-        PVSTR: initial_string_value,
         PVLONG: initial_long_value,
     }
     first_msg, _ = poll_for_valid_message(consumer)
-    second_msg, _ = poll_for_valid_message(consumer)
-    messages = [first_msg, second_msg]
+    messages = [first_msg,]
     check_multiple_expected_values(messages, expected_values)
     producer.remove_config(pvs)
 

--- a/system_tests/test_forwarding.py
+++ b/system_tests/test_forwarding.py
@@ -184,7 +184,9 @@ def forwarding_floatarray(consumer: Consumer, producer: ProducerWrapper):
 
 
 def forwarding_long(consumer: Consumer, producer: ProducerWrapper):
-    pvs = [PVLONG, ]
+    pvs = [
+        PVLONG,
+    ]
     producer.add_config(pvs)
     # Wait for config to be pushed
     sleep(5)
@@ -195,7 +197,9 @@ def forwarding_long(consumer: Consumer, producer: ProducerWrapper):
         PVLONG: initial_long_value,
     }
     first_msg, _ = poll_for_valid_message(consumer)
-    messages = [first_msg, ]
+    messages = [
+        first_msg,
+    ]
     check_multiple_expected_values(messages, expected_values)
     producer.remove_config(pvs)
 

--- a/system_tests/test_forwarding.py
+++ b/system_tests/test_forwarding.py
@@ -27,7 +27,6 @@ from .helpers.producerwrapper import ProducerWrapper
 from .helpers.PVs import (
     PVDOUBLE,
     PVDOUBLE_WITH_ALARM_THRESHOLDS,
-    PVENUM,
     PVFLOATARRAY,
     PVLONG,
     PVSTR,
@@ -196,7 +195,7 @@ def forwarding_long(consumer: Consumer, producer: ProducerWrapper):
         PVLONG: initial_long_value,
     }
     first_msg, _ = poll_for_valid_message(consumer)
-    messages = [first_msg,]
+    messages = [first_msg, ]
     check_multiple_expected_values(messages, expected_values)
     producer.remove_config(pvs)
 

--- a/tests/kafka/kafka_helpers_test.py
+++ b/tests/kafka/kafka_helpers_test.py
@@ -1,8 +1,6 @@
 import pytest
 
-from forwarder.kafka.kafka_helpers import (
-    get_broker_and_topic_from_uri,
-)
+from forwarder.kafka.kafka_helpers import get_broker_and_topic_from_uri
 
 
 def test_raises_exception_if_no_forward_slash_present():

--- a/tests/kafka/kafka_helpers_test.py
+++ b/tests/kafka/kafka_helpers_test.py
@@ -4,7 +4,6 @@ from streaming_data_types.timestamps_tdct import deserialise_tdct
 
 from forwarder.kafka.kafka_helpers import (
     get_broker_and_topic_from_uri,
-    publish_tdct_message,
 )
 from tests.kafka.fake_producer import FakeProducer
 
@@ -40,67 +39,3 @@ def test_uri_with_port_after_broker_is_included_in_broker_output():
     broker, topic = get_broker_and_topic_from_uri(test_uri)
     assert broker == test_broker
     assert topic == test_topic
-
-
-def test_tdct_publisher_converts_relative_timestamp_to_absolute():
-    producer = FakeProducer()
-    # These are the values that would be in the array in the PV update
-    input_relative_timestamps = np.array([1, 2, 3]).astype(np.uint32)
-    # This is the timestamp of the PV update
-    reference_timestamp = 10
-    publish_tdct_message(
-        producer,  # type: ignore
-        "test_topic",
-        input_relative_timestamps,
-        "test_source",
-        reference_timestamp,
-    )
-
-    assert producer.published_payload is not None
-    published_data = deserialise_tdct(producer.published_payload)
-    assert np.array_equal(
-        published_data.timestamps, input_relative_timestamps + reference_timestamp
-    ), "Expected the relative timestamps from the EPICS update to have been converted to unix timestamps"
-
-
-def test_tdct_publisher_handles_negative_relative_timestamps():
-    producer = FakeProducer()
-    # These are the values that would be in the array in the PV update
-    input_relative_timestamps = np.array([-3, -2, -1]).astype(np.uint32)
-    # This is the timestamp of the PV update
-    reference_timestamp = 10
-    publish_tdct_message(
-        producer,  # type: ignore
-        "test_topic",
-        input_relative_timestamps,
-        "test_source",
-        reference_timestamp,
-    )
-
-    assert producer.published_payload is not None
-    published_data = deserialise_tdct(producer.published_payload)
-    assert np.array_equal(
-        published_data.timestamps, input_relative_timestamps + reference_timestamp
-    ), "Expected the relative timestamps from the EPICS update to have been converted to unix timestamps"
-
-
-def test_tdct_publisher_publishes_successfully_when_there_is_only_a_single_chopper_timestamp():
-    producer = FakeProducer()
-    # These are the values that would be in the array in the PV update
-    input_relative_timestamps = np.array(1).astype(np.uint32)
-    # This is the timestamp of the PV update
-    reference_timestamp = 10
-    publish_tdct_message(
-        producer,  # type: ignore
-        "test_topic",
-        input_relative_timestamps,
-        "test_source",
-        reference_timestamp,
-    )
-
-    assert producer.published_payload is not None
-    published_data = deserialise_tdct(producer.published_payload)
-    assert np.array_equal(
-        published_data.timestamps,
-        np.atleast_1d(input_relative_timestamps + reference_timestamp),
-    ), "Expected the relative timestamps from the EPICS update to have been converted to unix timestamps"

--- a/tests/kafka/kafka_helpers_test.py
+++ b/tests/kafka/kafka_helpers_test.py
@@ -1,11 +1,8 @@
-import numpy as np
 import pytest
-from streaming_data_types.timestamps_tdct import deserialise_tdct
 
 from forwarder.kafka.kafka_helpers import (
     get_broker_and_topic_from_uri,
 )
-from tests.kafka.fake_producer import FakeProducer
 
 
 def test_raises_exception_if_no_forward_slash_present():

--- a/tests/update_handlers/base_update_handler_test.py
+++ b/tests/update_handlers/base_update_handler_test.py
@@ -1,6 +1,7 @@
-from forwarder.update_handlers.base_update_handler import BaseUpdateHandler
 from datetime import datetime, timedelta
 from unittest import mock
+
+from forwarder.update_handlers.base_update_handler import BaseUpdateHandler
 
 
 def test_accepted_timestamp():

--- a/tests/update_handlers/ca_update_handler_test.py
+++ b/tests/update_handlers/ca_update_handler_test.py
@@ -1,7 +1,7 @@
+import time
 from cmath import isclose
 from time import sleep
 from typing import List
-import time
 
 import numpy as np
 import pytest

--- a/tests/update_handlers/ca_update_handler_test.py
+++ b/tests/update_handlers/ca_update_handler_test.py
@@ -56,7 +56,7 @@ def test_update_handler_publishes_float_update(
     )
 
     assert producer.published_payload is not None
-    pv_update_output = deserialise_f142(producer.published_payload[0])
+    pv_update_output = deserialise_f142(producer.published_payload)
     assert isclose(pv_update_output.value, pv_value, abs_tol=0.0001)
     assert pv_update_output.source_name == pv_source_name
 
@@ -87,7 +87,7 @@ def test_update_handler_publishes_int_update(pv_value, pv_caproto_type, pv_numpy
     )
 
     assert producer.published_payload is not None
-    pv_update_output = deserialise_f142(producer.published_payload[0])
+    pv_update_output = deserialise_f142(producer.published_payload)
     assert pv_update_output.value == pv_value
     assert pv_update_output.source_name == pv_source_name
 
@@ -131,7 +131,7 @@ def test_update_handler_publishes_floatarray_update(
     )
 
     assert producer.published_payload is not None
-    pv_update_output = deserialise_f142(producer.published_payload[0])
+    pv_update_output = deserialise_f142(producer.published_payload)
     assert np.allclose(pv_update_output.value, pv_value)
     assert pv_update_output.source_name == pv_source_name
 
@@ -164,7 +164,7 @@ def test_update_handler_publishes_alarm_update():
     )
 
     assert producer.published_payload is not None
-    pv_update_output = deserialise_f142(producer.published_payload[0])
+    pv_update_output = deserialise_f142(producer.published_payload)
     assert pv_update_output.value == pv_value
     assert pv_update_output.source_name == pv_source_name
     assert pv_update_output.alarm_status == AlarmStatus.LOW
@@ -197,7 +197,7 @@ def test_update_handler_publishes_periodic_update():
     )
 
     assert producer.published_payload is not None
-    pv_update_output = deserialise_f142(producer.published_payload[0])
+    pv_update_output = deserialise_f142(producer.published_payload)
     assert pv_update_output.value == pv_value
     assert pv_update_output.source_name == pv_source_name
 
@@ -245,7 +245,7 @@ def test_update_handler_does_not_include_alarm_details_if_unchanged_in_subsequen
     )
 
     assert producer.messages_published == 2
-    pv_update_output = deserialise_f142(producer.published_payload[0])
+    pv_update_output = deserialise_f142(producer.published_payload)
     assert pv_update_output.alarm_status == AlarmStatus.NO_CHANGE
     assert pv_update_output.alarm_severity == AlarmSeverity.NO_CHANGE
 
@@ -276,7 +276,7 @@ def test_update_handler_publishes_enum_update():
 
     assert producer.messages_published == 1
     assert producer.published_payload is not None
-    pv_update_output = deserialise_f142(producer.published_payload[0])
+    pv_update_output = deserialise_f142(producer.published_payload)
     assert pv_update_output.value == 0
     assert pv_update_output.source_name == pv_source_name
 
@@ -324,7 +324,7 @@ def test_empty_update_is_not_forwarded():
     assert (
         producer.messages_published == 1
     ), "Expected only the one PV update with non-empty value array to have been published"
-    pv_update_output = deserialise_tdct(producer.published_payload[0])
+    pv_update_output = deserialise_tdct(producer.published_payload)
     assert (
         pv_update_output.timestamps.size > 0
     ), "Expected the published PV update not to be empty"

--- a/tests/update_handlers/ca_update_handler_test.py
+++ b/tests/update_handlers/ca_update_handler_test.py
@@ -56,7 +56,7 @@ def test_update_handler_publishes_float_update(
     )
 
     assert producer.published_payload is not None
-    pv_update_output = deserialise_f142(producer.published_payload)
+    pv_update_output = deserialise_f142(producer.published_payload[0])
     assert isclose(pv_update_output.value, pv_value, abs_tol=0.0001)
     assert pv_update_output.source_name == pv_source_name
 
@@ -87,7 +87,7 @@ def test_update_handler_publishes_int_update(pv_value, pv_caproto_type, pv_numpy
     )
 
     assert producer.published_payload is not None
-    pv_update_output = deserialise_f142(producer.published_payload)
+    pv_update_output = deserialise_f142(producer.published_payload[0])
     assert pv_update_output.value == pv_value
     assert pv_update_output.source_name == pv_source_name
 
@@ -131,7 +131,7 @@ def test_update_handler_publishes_floatarray_update(
     )
 
     assert producer.published_payload is not None
-    pv_update_output = deserialise_f142(producer.published_payload)
+    pv_update_output = deserialise_f142(producer.published_payload[0])
     assert np.allclose(pv_update_output.value, pv_value)
     assert pv_update_output.source_name == pv_source_name
 
@@ -164,7 +164,7 @@ def test_update_handler_publishes_alarm_update():
     )
 
     assert producer.published_payload is not None
-    pv_update_output = deserialise_f142(producer.published_payload)
+    pv_update_output = deserialise_f142(producer.published_payload[0])
     assert pv_update_output.value == pv_value
     assert pv_update_output.source_name == pv_source_name
     assert pv_update_output.alarm_status == AlarmStatus.LOW
@@ -197,7 +197,7 @@ def test_update_handler_publishes_periodic_update():
     )
 
     assert producer.published_payload is not None
-    pv_update_output = deserialise_f142(producer.published_payload)
+    pv_update_output = deserialise_f142(producer.published_payload[0])
     assert pv_update_output.value == pv_value
     assert pv_update_output.source_name == pv_source_name
 
@@ -245,7 +245,7 @@ def test_update_handler_does_not_include_alarm_details_if_unchanged_in_subsequen
     )
 
     assert producer.messages_published == 2
-    pv_update_output = deserialise_f142(producer.published_payload)
+    pv_update_output = deserialise_f142(producer.published_payload[0])
     assert pv_update_output.alarm_status == AlarmStatus.NO_CHANGE
     assert pv_update_output.alarm_severity == AlarmSeverity.NO_CHANGE
 
@@ -273,25 +273,11 @@ def test_update_handler_publishes_enum_update():
             metadata=metadata,
         )
     )
-    # Second update, with STRING type
-    enum_string_value = "ENUM_STRING"
-    context.call_monitor_callback_with_fake_pv_update(
-        ReadNotifyResponse(
-            [enum_string_value.encode("utf8")],
-            ChannelType.TIME_STRING,
-            1,
-            1,
-            1,
-            metadata=metadata,
-        )
-    )
 
-    assert (
-        producer.messages_published == 1
-    ), "Only expected a single message with string payload, not the original enum update"
+    assert producer.messages_published == 1
     assert producer.published_payload is not None
-    pv_update_output = deserialise_f142(producer.published_payload)
-    assert pv_update_output.value == enum_string_value
+    pv_update_output = deserialise_f142(producer.published_payload[0])
+    assert pv_update_output.value == 0
     assert pv_update_output.source_name == pv_source_name
 
     update_handler.stop()
@@ -338,7 +324,7 @@ def test_empty_update_is_not_forwarded():
     assert (
         producer.messages_published == 1
     ), "Expected only the one PV update with non-empty value array to have been published"
-    pv_update_output = deserialise_tdct(producer.published_payload)
+    pv_update_output = deserialise_tdct(producer.published_payload[0])
     assert (
         pv_update_output.timestamps.size > 0
     ), "Expected the published PV update not to be empty"

--- a/tests/update_handlers/fake_update_handler_test.py
+++ b/tests/update_handlers/fake_update_handler_test.py
@@ -21,7 +21,7 @@ def test_update_handler_publishes_f142_update():
     fake_update_handler._timer_callback()
 
     assert producer.published_payload is not None
-    pv_update_output = deserialise_f142(producer.published_payload[0])
+    pv_update_output = deserialise_f142(producer.published_payload)
     assert pv_update_output.source_name == pv_source_name
 
     fake_update_handler.stop()
@@ -35,7 +35,7 @@ def test_update_handler_publishes_tdct_update():
     fake_update_handler._timer_callback()
 
     assert producer.published_payload is not None
-    pv_update_output = deserialise_tdct(producer.published_payload[0])
+    pv_update_output = deserialise_tdct(producer.published_payload)
     assert pv_update_output.name == pv_source_name
 
     fake_update_handler.stop()

--- a/tests/update_handlers/fake_update_handler_test.py
+++ b/tests/update_handlers/fake_update_handler_test.py
@@ -21,7 +21,7 @@ def test_update_handler_publishes_f142_update():
     fake_update_handler._timer_callback()
 
     assert producer.published_payload is not None
-    pv_update_output = deserialise_f142(producer.published_payload)
+    pv_update_output = deserialise_f142(producer.published_payload[0])
     assert pv_update_output.source_name == pv_source_name
 
     fake_update_handler.stop()
@@ -35,7 +35,7 @@ def test_update_handler_publishes_tdct_update():
     fake_update_handler._timer_callback()
 
     assert producer.published_payload is not None
-    pv_update_output = deserialise_tdct(producer.published_payload)
+    pv_update_output = deserialise_tdct(producer.published_payload[0])
     assert pv_update_output.name == pv_source_name
 
     fake_update_handler.stop()

--- a/tests/update_handlers/nttable_senv_test.py
+++ b/tests/update_handlers/nttable_senv_test.py
@@ -12,8 +12,8 @@ def test_serialise_nttable():
 
     table = NTTable.buildType(
         columns=[
-            ("value", "ah"),
-            ("timestamp", "aL"),
+            ("column0", "ah"),
+            ("column1", "aL"),
         ]
     )
 
@@ -21,7 +21,7 @@ def test_serialise_nttable():
         table,
         {
             "labels": ["value", "timestamp"],
-            "value": {"value": values, "timestamp": timestamps},
+            "value": {"column0": values, "column1": timestamps},
         },
     )
 

--- a/tests/update_handlers/nttable_senv_test.py
+++ b/tests/update_handlers/nttable_senv_test.py
@@ -10,13 +10,20 @@ def test_serialise_nttable():
     values = np.arange(-50, 50, dtype=np.int16)
     timestamps = np.arange(50, 150, dtype=np.uint64)
 
-    table = NTTable.buildType(columns=[
-        ('value', 'ah'),
-        ('timestamp', 'aL'),
-    ])
+    table = NTTable.buildType(
+        columns=[
+            ("value", "ah"),
+            ("timestamp", "aL"),
+        ]
+    )
 
-    update = Value(table, {"labels": ["value", "timestamp"],
-                           "value": {"value": values, "timestamp": timestamps}})
+    update = Value(
+        table,
+        {
+            "labels": ["value", "timestamp"],
+            "value": {"value": values, "timestamp": timestamps},
+        },
+    )
 
     pv_name = "some_pv"
     serialiser = nttable_senv_Serialiser(pv_name)

--- a/tests/update_handlers/nttable_senv_test.py
+++ b/tests/update_handlers/nttable_senv_test.py
@@ -3,7 +3,7 @@ from p4p import Value
 from forwarder.update_handlers.nttable_senv_serialiser import nttable_senv_Serialiser
 from streaming_data_types.sample_environment_senv import deserialise_senv
 import numpy as np
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 def test_serialise_nttable():
@@ -35,5 +35,5 @@ def test_serialise_nttable():
     assert np.array_equal(fb_update.values, values)
     assert fb_update.values.dtype == values.dtype
     assert np.array_equal(fb_update.value_ts, timestamps)
-    assert fb_update.timestamp == datetime.fromtimestamp(timestamps[0] / 1e9)
+    assert fb_update.timestamp == datetime.fromtimestamp(timestamps[0] / 1e9, tz=timezone.utc)
     assert fb_update.message_counter == 0

--- a/tests/update_handlers/nttable_senv_test.py
+++ b/tests/update_handlers/nttable_senv_test.py
@@ -35,5 +35,7 @@ def test_serialise_nttable():
     assert np.array_equal(fb_update.values, values)
     assert fb_update.values.dtype == values.dtype
     assert np.array_equal(fb_update.value_ts, timestamps)
-    assert fb_update.timestamp == datetime.fromtimestamp(timestamps[0] / 1e9, tz=timezone.utc)
+    assert fb_update.timestamp == datetime.fromtimestamp(
+        timestamps[0] / 1e9, tz=timezone.utc
+    )
     assert fb_update.message_counter == 0

--- a/tests/update_handlers/nttable_senv_test.py
+++ b/tests/update_handlers/nttable_senv_test.py
@@ -1,9 +1,11 @@
-from p4p.nt import NTTable
-from p4p import Value
-from forwarder.update_handlers.nttable_senv_serialiser import nttable_senv_Serialiser
-from streaming_data_types.sample_environment_senv import deserialise_senv
-import numpy as np
 from datetime import datetime, timezone
+
+import numpy as np
+from p4p import Value
+from p4p.nt import NTTable
+from streaming_data_types.sample_environment_senv import deserialise_senv
+
+from forwarder.update_handlers.nttable_senv_serialiser import nttable_senv_Serialiser
 
 
 def test_serialise_nttable():

--- a/tests/update_handlers/nttable_senv_test.py
+++ b/tests/update_handlers/nttable_senv_test.py
@@ -1,0 +1,32 @@
+from p4p.nt import NTTable
+from p4p import Value
+from forwarder.update_handlers.nttable_senv_serialiser import nttable_senv_Serialiser
+from streaming_data_types.sample_environment_senv import deserialise_senv
+import numpy as np
+from datetime import datetime
+
+
+def test_serialise_nttable():
+    values = np.arange(-50, 50, dtype=np.int16)
+    timestamps = np.arange(50, 150, dtype=np.uint64)
+
+    table = NTTable.buildType(columns=[
+        ('value', 'ah'),
+        ('timestamp', 'aL'),
+    ])
+
+    update = Value(table, {"labels": ["value", "timestamp"],
+                           "value": {"value": values, "timestamp": timestamps}})
+
+    pv_name = "some_pv"
+    serialiser = nttable_senv_Serialiser(pv_name)
+    message, timestamp = serialiser.serialise(update)
+
+    fb_update = deserialise_senv(message)
+
+    assert fb_update.name == pv_name
+    assert np.array_equal(fb_update.values, values)
+    assert fb_update.values.dtype == values.dtype
+    assert np.array_equal(fb_update.value_ts, timestamps)
+    assert fb_update.timestamp == datetime.fromtimestamp(timestamps[0] / 1e9)
+    assert fb_update.message_counter == 0

--- a/tests/update_handlers/pva_update_handler_test.py
+++ b/tests/update_handlers/pva_update_handler_test.py
@@ -46,7 +46,7 @@ def test_update_handler_publishes_enum_update():
     )
 
     assert producer.published_payload is not None
-    pv_update_output = deserialise_f142(producer.published_payload[0])
+    pv_update_output = deserialise_f142(producer.published_payload)
     assert pv_update_output.value == 0
     assert pv_update_output.source_name == pv_source_name
 
@@ -67,7 +67,7 @@ def test_update_handler_publishes_float_update(pv_value, pv_type):
     )
 
     assert producer.published_payload is not None
-    pv_update_output = deserialise_f142(producer.published_payload[0])
+    pv_update_output = deserialise_f142(producer.published_payload)
     assert isclose(pv_update_output.value, pv_value, abs_tol=0.0001)
     assert pv_update_output.source_name == pv_source_name
 
@@ -91,7 +91,7 @@ def test_update_handler_publishes_int_update(pv_value, pv_type):
     )
 
     assert producer.published_payload is not None
-    pv_update_output = deserialise_f142(producer.published_payload[0])
+    pv_update_output = deserialise_f142(producer.published_payload)
     assert pv_update_output.value == pv_value
     assert pv_update_output.source_name == pv_source_name
 
@@ -118,7 +118,7 @@ def test_update_handler_publishes_floatarray_update(pv_value, pv_type):
     )
 
     assert producer.published_payload is not None
-    pv_update_output = deserialise_f142(producer.published_payload[0])
+    pv_update_output = deserialise_f142(producer.published_payload)
     assert np.allclose(pv_update_output.value, pv_value)
     assert pv_update_output.source_name == pv_source_name
 
@@ -153,7 +153,7 @@ def test_update_handler_publishes_alarm_update():
     )
 
     assert producer.published_payload is not None
-    pv_update_output = deserialise_f142(producer.published_payload[0])
+    pv_update_output = deserialise_f142(producer.published_payload)
     assert pv_update_output.value == pv_value
     assert pv_update_output.source_name == pv_source_name
     assert pv_update_output.alarm_status == AlarmStatus.HIGH
@@ -178,7 +178,7 @@ def test_update_handler_publishes_periodic_update():
     )
 
     assert producer.published_payload is not None
-    pv_update_output = deserialise_f142(producer.published_payload[0])
+    pv_update_output = deserialise_f142(producer.published_payload)
     assert pv_update_output.value == pv_value
     assert pv_update_output.source_name == pv_source_name
 
@@ -232,7 +232,7 @@ def test_update_handler_does_not_include_alarm_details_if_unchanged_in_subsequen
     )
 
     assert producer.messages_published == 2
-    pv_update_output = deserialise_f142(producer.published_payload[0])
+    pv_update_output = deserialise_f142(producer.published_payload)
     assert pv_update_output.alarm_status == AlarmStatus.NO_CHANGE
     assert pv_update_output.alarm_severity == AlarmSeverity.NO_CHANGE
 
@@ -266,7 +266,7 @@ def test_empty_update_is_not_forwarded():
     assert (
         producer.messages_published == 1
     ), "Expected only the one PV update with non-empty value array to have been published"
-    pv_update_output = deserialise_tdct(producer.published_payload[0])
+    pv_update_output = deserialise_tdct(producer.published_payload)
     assert (
         pv_update_output.timestamps.size > 0
     ), "Expected the published PV update not to be empty"

--- a/tests/update_handlers/pva_update_handler_test.py
+++ b/tests/update_handlers/pva_update_handler_test.py
@@ -46,8 +46,8 @@ def test_update_handler_publishes_enum_update():
     )
 
     assert producer.published_payload is not None
-    pv_update_output = deserialise_f142(producer.published_payload)
-    assert pv_update_output.value == pv_value_str
+    pv_update_output = deserialise_f142(producer.published_payload[0])
+    assert pv_update_output.value == 0
     assert pv_update_output.source_name == pv_source_name
 
     pva_update_handler.stop()
@@ -67,7 +67,7 @@ def test_update_handler_publishes_float_update(pv_value, pv_type):
     )
 
     assert producer.published_payload is not None
-    pv_update_output = deserialise_f142(producer.published_payload)
+    pv_update_output = deserialise_f142(producer.published_payload[0])
     assert isclose(pv_update_output.value, pv_value, abs_tol=0.0001)
     assert pv_update_output.source_name == pv_source_name
 
@@ -91,7 +91,7 @@ def test_update_handler_publishes_int_update(pv_value, pv_type):
     )
 
     assert producer.published_payload is not None
-    pv_update_output = deserialise_f142(producer.published_payload)
+    pv_update_output = deserialise_f142(producer.published_payload[0])
     assert pv_update_output.value == pv_value
     assert pv_update_output.source_name == pv_source_name
 
@@ -118,7 +118,7 @@ def test_update_handler_publishes_floatarray_update(pv_value, pv_type):
     )
 
     assert producer.published_payload is not None
-    pv_update_output = deserialise_f142(producer.published_payload)
+    pv_update_output = deserialise_f142(producer.published_payload[0])
     assert np.allclose(pv_update_output.value, pv_value)
     assert pv_update_output.source_name == pv_source_name
 
@@ -153,7 +153,7 @@ def test_update_handler_publishes_alarm_update():
     )
 
     assert producer.published_payload is not None
-    pv_update_output = deserialise_f142(producer.published_payload)
+    pv_update_output = deserialise_f142(producer.published_payload[0])
     assert pv_update_output.value == pv_value
     assert pv_update_output.source_name == pv_source_name
     assert pv_update_output.alarm_status == AlarmStatus.HIGH
@@ -178,7 +178,7 @@ def test_update_handler_publishes_periodic_update():
     )
 
     assert producer.published_payload is not None
-    pv_update_output = deserialise_f142(producer.published_payload)
+    pv_update_output = deserialise_f142(producer.published_payload[0])
     assert pv_update_output.value == pv_value
     assert pv_update_output.source_name == pv_source_name
 
@@ -232,7 +232,7 @@ def test_update_handler_does_not_include_alarm_details_if_unchanged_in_subsequen
     )
 
     assert producer.messages_published == 2
-    pv_update_output = deserialise_f142(producer.published_payload)
+    pv_update_output = deserialise_f142(producer.published_payload[0])
     assert pv_update_output.alarm_status == AlarmStatus.NO_CHANGE
     assert pv_update_output.alarm_severity == AlarmSeverity.NO_CHANGE
 
@@ -266,7 +266,7 @@ def test_empty_update_is_not_forwarded():
     assert (
         producer.messages_published == 1
     ), "Expected only the one PV update with non-empty value array to have been published"
-    pv_update_output = deserialise_tdct(producer.published_payload)
+    pv_update_output = deserialise_tdct(producer.published_payload[0])
     assert (
         pv_update_output.timestamps.size > 0
     ), "Expected the published PV update not to be empty"

--- a/tests/update_handlers/tdct_test.py
+++ b/tests/update_handlers/tdct_test.py
@@ -3,6 +3,7 @@ from forwarder.update_handlers.tdct_serialiser import tdct_Serialiser
 from streaming_data_types.timestamps_tdct import deserialise_tdct
 from p4p.nt import NTScalar
 
+
 def test_tdct_serialiser_handles_negative_relative_timestamps():
     input_relative_timestamps = np.array([-3, -2, -1]).astype(np.int32)
     # This is the timestamp of the PV update

--- a/tests/update_handlers/tdct_test.py
+++ b/tests/update_handlers/tdct_test.py
@@ -1,7 +1,8 @@
 import numpy as np
-from forwarder.update_handlers.tdct_serialiser import tdct_Serialiser
-from streaming_data_types.timestamps_tdct import deserialise_tdct
 from p4p.nt import NTScalar
+from streaming_data_types.timestamps_tdct import deserialise_tdct
+
+from forwarder.update_handlers.tdct_serialiser import tdct_Serialiser
 
 
 def test_tdct_serialiser_handles_negative_relative_timestamps():

--- a/tests/update_handlers/tdct_test.py
+++ b/tests/update_handlers/tdct_test.py
@@ -1,0 +1,40 @@
+import numpy as np
+from forwarder.update_handlers.tdct_serialiser import tdct_Serialiser
+from streaming_data_types.timestamps_tdct import deserialise_tdct
+from p4p.nt import NTScalar
+
+def test_tdct_serialiser_handles_negative_relative_timestamps():
+    input_relative_timestamps = np.array([-3, -2, -1]).astype(np.int32)
+    # This is the timestamp of the PV update
+    reference_timestamp = 10
+    serialiser = tdct_Serialiser("tst_source")
+
+    update = NTScalar("ai").wrap(input_relative_timestamps)
+    update.timeStamp.secondsPastEpoch = 0
+    update.timeStamp.nanoseconds = reference_timestamp
+
+    message = serialiser.serialise(update)
+
+    published_data = deserialise_tdct(message[0])
+    assert np.array_equal(
+        published_data.timestamps, input_relative_timestamps + reference_timestamp
+    ), "Expected the relative timestamps from the EPICS update to have been converted to unix timestamps"
+
+
+def test_tdct_publisher_publishes_successfully_when_there_is_only_a_single_chopper_timestamp():
+    # These are the values that would be in the array in the PV update
+    input_relative_timestamps = 1
+    # This is the timestamp of the PV update
+    reference_timestamp = 10
+    update = NTScalar("i").wrap(input_relative_timestamps)
+    update.timeStamp.secondsPastEpoch = 0
+    update.timeStamp.nanoseconds = reference_timestamp
+
+    serialiser = tdct_Serialiser("tst_source")
+    message = serialiser.serialise(update)
+
+    published_data = deserialise_tdct(message[0])
+    assert np.array_equal(
+        published_data.timestamps,
+        np.atleast_1d(input_relative_timestamps + reference_timestamp),
+    ), "Expected the relative timestamps from the EPICS update to have been converted to unix timestamps"


### PR DESCRIPTION
## Description

This required more changes than I had initially thought. A general outline follows:

* Moved flatbuffer serialisation into classes to modularise the code.
* Removed serialisation of enums as strings to conform to the NeXus standard and the file-writer implementation.
* Changed responsibility for value extraction from ca/pva handlers to the serialisation code.
* Implemented conversion of (some specific) NTTables  into senv flatbuffers.

On top of that I also had to implement some bug fixes and other minor improvements to make the tests run properly.