### PR TITLE
Bumped numpy version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,7 +77,7 @@ builders = pipeline_builder.createBuilders { container ->
       export PATH=/opt/miniconda/bin:$PATH
       python --version
       cd ${project}
-      python -m pytest --cov=forwarder --cov-report=xml --junitxml=${test_output}
+      python -m tox --cov=forwarder --cov-report=xml --junitxml=${test_output}
     """
     container.copyFrom("${project}/${test_output}", ".")
     xunit thresholds: [failed(unstableThreshold: '0')], tools: [JUnit(deleteOutputFiles: true, pattern: '*.xml', skipNoTestFiles: false, stopProcessingIfError: true)]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,7 +77,7 @@ builders = pipeline_builder.createBuilders { container ->
       export PATH=/opt/miniconda/bin:$PATH
       python --version
       cd ${project}
-      python -m tox --cov=forwarder --cov-report=xml --junitxml=${test_output}
+      python -m tox -- --cov=forwarder --cov-report=xml --junitxml=${test_output}
     """
     container.copyFrom("${project}/${test_output}", ".")
     xunit thresholds: [failed(unstableThreshold: '0')], tools: [JUnit(deleteOutputFiles: true, pattern: '*.xml', skipNoTestFiles: false, stopProcessingIfError: true)]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@
 pre-commit
 pytest
 pytest-cov
+tox
 wheel
 # Pin to match versions in precommit hooks
 black==21.5b2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ confluent_kafka == 1.7.0
 flatbuffers == 1.12
 graypy == 2.1.0
 graphyte == 1.6.0
-numpy == 1.20.3
+numpy == 1.21.2
 attrs == 21.2.0
 ConfigArgParse == 1.4.1
 ess-streaming-data-types == 0.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 caproto == 0.8.1
-p4p == 3.5.3
+p4p == 3.5.4
 confluent_kafka == 1.7.0
 flatbuffers == 1.12
 graypy == 2.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py37, py38, py39
+requires = tox-conda
+isolated_build = true
+skipsdist=true
+
+[testenv]
+deps =
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/requirements-dev.txt
+commands =
+    python -m pytest {posargs}


### PR DESCRIPTION
pip complains that the numpy version conflicts with the requirements for p4p (on the build server anyway, I don't see the same issue on mac)