### PR TITLE
Replace dots in hostnames for metrics

### DIFF
--- a/forwarder_launch.py
+++ b/forwarder_launch.py
@@ -85,7 +85,8 @@ if __name__ == "__main__":
 
     statistic_reporter = None
     if grafana_carbon_address:
-        prefix = f"Forwarder.{gethostname()}.{args.service_id}".replace(" ", "").lower()
+        metric_hostname = gethostname().replace(".", "_")
+        prefix = f"Forwarder.{metric_hostname}.{args.service_id}".replace(" ", "").lower()
         statistic_reporter = StatisticsReporter(
             grafana_carbon_address,
             update_handlers,

--- a/forwarder_launch.py
+++ b/forwarder_launch.py
@@ -86,7 +86,9 @@ if __name__ == "__main__":
     statistic_reporter = None
     if grafana_carbon_address:
         metric_hostname = gethostname().replace(".", "_")
-        prefix = f"Forwarder.{metric_hostname}.{args.service_id}".replace(" ", "").lower()
+        prefix = f"Forwarder.{metric_hostname}.{args.service_id}".replace(
+            " ", ""
+        ).lower()
         statistic_reporter = StatisticsReporter(
             grafana_carbon_address,
             update_handlers,


### PR DESCRIPTION
The dots cause the metric names to be broken into additional components.