### PR TITLE
Adding se00 schema

### DIFF
--- a/forwarder/update_handlers/nttable_se00_serialiser.py
+++ b/forwarder/update_handlers/nttable_se00_serialiser.py
@@ -1,0 +1,51 @@
+from typing import Tuple, Union
+
+import numpy as np
+import p4p
+from streaming_data_types.array_1d_se00 import serialise_se00
+
+from forwarder.update_handlers.schema_serialisers import PVASerialiser
+
+
+class nttable_se00_PVASerialiser(PVASerialiser):
+    def __init__(self, source_name: str):
+        self._source_name = source_name
+        self._msg_counter = -1
+
+    def serialise(
+        self, update: Union[p4p.Value, RuntimeError], **unused
+    ) -> Union[Tuple[bytes, int], Tuple[None, None]]:
+        if isinstance(update, RuntimeError):
+            return None, None
+        if update.getID() != "epics:nt/NTTable:1.0":
+            raise RuntimeError(
+                f'Unable to process EPICS updates of type: "{update.getID()}".'
+            )
+        column_headers = update.labels
+        if "value" not in column_headers or "timestamp" not in column_headers:
+            raise RuntimeError(
+                f'Unable to find required columns ("value", "timestamp") in NTTable. Found the columns {column_headers} instead.'
+            )
+        tables = update.value.items()
+        values = tables[column_headers.index("value")][1]
+        if np.issubdtype(values.dtype, np.floating):
+            values = values.round().astype(np.int64)
+        timestamps = tables[column_headers.index("timestamp")][1]
+        if len(timestamps) == 0:
+            return None, None
+        self._msg_counter += 1
+        origin_timestamp = timestamps[0]
+        message_timestamp = timestamps[0]
+        delta_time = timestamps[1] - timestamps[0]
+        return (
+            serialise_se00(
+                name=self._source_name,
+                value_timestamps=timestamps,
+                values=values,
+                timestamp_unix_ns=message_timestamp,
+                message_counter=self._msg_counter,
+                sample_ts_delta=delta_time,
+                channel=0,
+            ),
+            origin_timestamp,
+        )

--- a/tests/update_handlers/nttable_se00_test.py
+++ b/tests/update_handlers/nttable_se00_test.py
@@ -1,0 +1,39 @@
+import numpy as np
+from p4p import Value
+from p4p.nt import NTTable
+from streaming_data_types.array_1d_se00 import deserialise_se00
+
+from forwarder.update_handlers.nttable_se00_serialiser import nttable_se00_PVASerialiser
+
+
+def test_serialise_nttable_se00():
+    values = np.arange(-50, 50, dtype=np.int16)
+    timestamps = np.arange(50, 150, dtype=np.uint64)
+
+    table = NTTable.buildType(
+        columns=[
+            ("column0", "ah"),
+            ("column1", "aL"),
+        ]
+    )
+
+    update = Value(
+        table,
+        {
+            "labels": ["value", "timestamp"],
+            "value": {"column0": values, "column1": timestamps},
+        },
+    )
+
+    pv_name = "some_pv"
+    serialiser = nttable_se00_PVASerialiser(pv_name)
+    message, timestamp = serialiser.serialise(update)
+
+    fb_update = deserialise_se00(message)
+
+    assert fb_update.name == pv_name
+    assert np.array_equal(fb_update.values, values)
+    assert fb_update.values.dtype == values.dtype
+    assert np.array_equal(fb_update.value_ts, timestamps)
+    assert fb_update.timestamp_unix_ns == timestamps[0]
+    assert fb_update.message_counter == 0


### PR DESCRIPTION
Added the se00 schema based on how senv is forwarded. The main difference here is that timestamps are used instead of datetime objects. 