### PR TITLE
Pin tox version in requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 pre-commit
 pytest
 pytest-cov
-tox
+tox==3.27.1
 wheel
 # Pin to match versions in precommit hooks
 black==22.10.0


### PR DESCRIPTION
We are having build issues with the latest major tox version (4), as it seems to tries to create environments inside existing ones, eventually exhausting the available disk space in builds.