### PR TITLE
Ecdc 3307 fix tdct handle empty array

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -6,6 +6,7 @@
 
 ## v2.0.0
 
+* Updating tdct to handle empty arrays coming from EPICS
 * Using ep01 instead of ep00 for EPICS connection events.
 * Adding the schema "se00", which is in an upgrade to the schema "senv" which could not handle floats/doubles.
 * Added support for f144 and al00 schemas.

--- a/forwarder/update_handlers/tdct_serialiser.py
+++ b/forwarder/update_handlers/tdct_serialiser.py
@@ -79,11 +79,14 @@ class tdct_PVASerialiser(PVASerialiser):
             raise RuntimeError(
                 f'Unable to extract TDC data from EPICS type: "{update.getID()}"'
             )
-        try:
-            if update.value.size == 0:
-                return None, None
-        except AttributeError:
-            pass
+        if isinstance(update.value, type(None)):
+            return None, None
+        else:
+            try:
+                if update.value.size == 0:
+                    return None, None
+            except AttributeError:
+                pass
         data_type = numpy_type_from_p4p_type[update.type()["value"][-1]]
         value_arr = np.squeeze(np.array(update.value)).astype(data_type)
         return self._serialise(value_arr, origin_time)

--- a/tests/update_handlers/tdct_test.py
+++ b/tests/update_handlers/tdct_test.py
@@ -5,6 +5,24 @@ from streaming_data_types.timestamps_tdct import deserialise_tdct
 from forwarder.update_handlers.tdct_serialiser import tdct_PVASerialiser
 
 
+def test_tdct_serialiser_handles_positive_relative_timestamps():
+    input_relative_timestamps = np.array([10, 11, 12]).astype(np.int32)
+    # This is the timestamp of the PV update
+    reference_timestamp = 10
+    serialiser = tdct_PVASerialiser("tst_source")
+
+    update = NTScalar("ai").wrap(input_relative_timestamps)
+    update.timeStamp.secondsPastEpoch = 0
+    update.timeStamp.nanoseconds = reference_timestamp
+
+    message = serialiser.serialise(update)
+
+    published_data = deserialise_tdct(message[0])
+    assert np.array_equal(
+        published_data.timestamps, input_relative_timestamps + reference_timestamp
+    ), "Expected the relative timestamps from the EPICS update to have been converted to unix timestamps"
+
+
 def test_tdct_serialiser_handles_negative_relative_timestamps():
     input_relative_timestamps = np.array([-3, -2, -1]).astype(np.int32)
     # This is the timestamp of the PV update
@@ -40,3 +58,21 @@ def test_tdct_publisher_publishes_successfully_when_there_is_only_a_single_chopp
         published_data.timestamps,
         np.atleast_1d(input_relative_timestamps + reference_timestamp),
     ), "Expected the relative timestamps from the EPICS update to have been converted to unix timestamps"
+
+
+def test_tdct_serialiser_handles_empty_array():
+    input_relative_timestamps = np.array([]).astype(np.int32)
+    # This is the timestamp of the PV update
+    reference_timestamp = 10
+    serialiser = tdct_PVASerialiser("tst_source")
+
+    update = NTScalar("ai").wrap(input_relative_timestamps)
+    update.timeStamp.secondsPastEpoch = 0
+    update.timeStamp.nanoseconds = reference_timestamp
+
+    message = serialiser.serialise(update)
+
+    assert message == (
+        None,
+        None,
+    ), "Expected serialiser to skip empty timestamp array from the EPICS update"


### PR DESCRIPTION
I made a minor change to try to catch the empty arrays that get turned into NoneTypes. I also added a test to verify this.

I'm just a little unsure if returning None, None is enough or if we need to do more in order not to forward the empty array.