### PR TITLE
ECDC-3313: Fix ep01 bug 

### DIFF
--- a/forwarder/update_handlers/ep01_serialiser.py
+++ b/forwarder/update_handlers/ep01_serialiser.py
@@ -88,9 +88,9 @@ class ep01_PVASerialiser(PVASerialiser):
 
         if (
             self._conn_status == ConnectionInfo.NEVER_CONNECTED
-            and conn_status == ConnectionInfo.DISCONNECTED
+            and conn_status != ConnectionInfo.CONNECTED
         ):
-            return _serialise(self._source_name, self._conn_status, timestamp)
+            return None, None
 
         self._conn_status = conn_status
         return _serialise(self._source_name, self._conn_status, timestamp)

--- a/forwarder/update_handlers/ep01_serialiser.py
+++ b/forwarder/update_handlers/ep01_serialiser.py
@@ -62,6 +62,7 @@ class ep01_PVASerialiser(PVASerialiser):
         self._source_name = source_name
         self._conn_status: ConnectionInfo = ConnectionInfo.NEVER_CONNECTED
         self._conn_state_map = {
+            p4p.Value: ConnectionInfo.CONNECTED,
             Cancelled: ConnectionInfo.CANCELLED,
             Disconnected: ConnectionInfo.DISCONNECTED,
             RemoteError: ConnectionInfo.REMOTE_ERROR,

--- a/forwarder/update_handlers/ep01_serialiser.py
+++ b/forwarder/update_handlers/ep01_serialiser.py
@@ -80,7 +80,7 @@ class ep01_PVASerialiser(PVASerialiser):
                 + update.timeStamp.nanoseconds
             )
 
-        conn_status = self.conn_state_map.get(type(update), ConnectionInfo.UNKNOWN)
+        conn_status = self._conn_state_map.get(type(update), ConnectionInfo.UNKNOWN)
 
         if conn_status == self._conn_status:
             # Nothing has changed

--- a/tests/update_handlers/ep01_serialiser_test.py
+++ b/tests/update_handlers/ep01_serialiser_test.py
@@ -23,7 +23,11 @@ def _test_serialise_start(pv_name, serialiser):
     assert fb_update.status == ConnectionInfo.NEVER_CONNECTED
 
 
+<<<<<<< HEAD
 def _create_value_update(reference_timestamp):
+=======
+def create_value_update(reference_timestamp):
+>>>>>>> 6749501 (added test that would have flagged bug and improved existing tests)
     test_data = np.array([-3, -2, -1]).astype(np.int32)
     update = NTScalar("ai").wrap(test_data)
     update.timeStamp.secondsPastEpoch = 0
@@ -38,6 +42,7 @@ def test_serialise_pva_start():
     return _test_serialise_start(pv_name, serialiser)
 
 
+<<<<<<< HEAD
 def test_if_disconnected_and_never_connected_returns_none():
     serialiser = ep01_PVASerialiser("some_pv")
 
@@ -45,11 +50,24 @@ def test_if_disconnected_and_never_connected_returns_none():
 
     assert message is None
     assert timestamp is None
+=======
+def test_if_disconnected_and_never_connected_send_never_connected():
+    serialiser = ep01_PVASerialiser("some_pv")
+
+    message, _ = serialiser.serialise(p4p.client.thread.Disconnected())
+
+    fb_update = deserialise_ep01(message)
+    assert fb_update.status == ConnectionInfo.NEVER_CONNECTED
+>>>>>>> 6749501 (added test that would have flagged bug and improved existing tests)
 
 
 def test_serialise_pva_value():
     reference_timestamp = 10
+<<<<<<< HEAD
     update = _create_value_update(reference_timestamp)
+=======
+    update = create_value_update(reference_timestamp)
+>>>>>>> 6749501 (added test that would have flagged bug and improved existing tests)
 
     pv_name = "some_pv"
     serialiser = ep01_PVASerialiser(pv_name)
@@ -64,7 +82,11 @@ def test_serialise_pva_value():
 
 def test_if_state_unchanged_then_message_is_none():
     reference_timestamp = 10
+<<<<<<< HEAD
     update = _create_value_update(reference_timestamp)
+=======
+    update = create_value_update(reference_timestamp)
+>>>>>>> 6749501 (added test that would have flagged bug and improved existing tests)
     pv_name = "some_pv"
     serialiser = ep01_PVASerialiser(pv_name)
     # First update
@@ -91,7 +113,11 @@ def test_connected_to_exception_transition(exception, state_enum):
     serialiser = ep01_PVASerialiser(pv_name)
 
     # First prime with a value update
+<<<<<<< HEAD
     serialiser.serialise(_create_value_update(123))
+=======
+    serialiser.serialise(create_value_update(123))
+>>>>>>> 6749501 (added test that would have flagged bug and improved existing tests)
 
     # Now try the exception
     message, timestamp = serialiser.serialise(exception)

--- a/tests/update_handlers/ep01_serialiser_test.py
+++ b/tests/update_handlers/ep01_serialiser_test.py
@@ -1,6 +1,7 @@
 import time
 
 import numpy as np
+import p4p.client.thread
 import pytest
 from p4p.client.thread import Cancelled, Disconnected, Finished, RemoteError
 from p4p.nt import NTScalar
@@ -22,6 +23,14 @@ def _test_serialise_start(pv_name, serialiser):
     assert fb_update.status == ConnectionInfo.NEVER_CONNECTED
 
 
+def create_value_update(reference_timestamp):
+    test_data = np.array([-3, -2, -1]).astype(np.int32)
+    update = NTScalar("ai").wrap(test_data)
+    update.timeStamp.secondsPastEpoch = 0
+    update.timeStamp.nanoseconds = reference_timestamp
+    return update
+
+
 def test_serialise_pva_start():
     pv_name = "some_pv"
     serialiser = ep01_PVASerialiser(pv_name)
@@ -29,12 +38,18 @@ def test_serialise_pva_start():
     return _test_serialise_start(pv_name, serialiser)
 
 
+def test_if_disconnected_and_never_connected_send_never_connected():
+    serialiser = ep01_PVASerialiser("some_pv")
+
+    message, _ = serialiser.serialise(p4p.client.thread.Disconnected())
+
+    fb_update = deserialise_ep01(message)
+    assert fb_update.status == ConnectionInfo.NEVER_CONNECTED
+
+
 def test_serialise_pva_value():
-    test_data = np.array([-3, -2, -1]).astype(np.int32)
     reference_timestamp = 10
-    update = NTScalar("ai").wrap(test_data)
-    update.timeStamp.secondsPastEpoch = 0
-    update.timeStamp.nanoseconds = reference_timestamp
+    update = create_value_update(reference_timestamp)
 
     pv_name = "some_pv"
     serialiser = ep01_PVASerialiser(pv_name)
@@ -46,6 +61,16 @@ def test_serialise_pva_value():
     assert fb_update.timestamp == reference_timestamp
     assert fb_update.status == ConnectionInfo.CONNECTED
 
+
+def test_if_state_unchanged_then_message_is_none():
+    reference_timestamp = 10
+    update = create_value_update(reference_timestamp)
+    pv_name = "some_pv"
+    serialiser = ep01_PVASerialiser(pv_name)
+    # First update
+    serialiser.serialise(update)
+
+    # Resend the same update
     message, timestamp = serialiser.serialise(update)
 
     assert message is None
@@ -64,6 +89,11 @@ def test_serialise_pva_value():
 def test_serialise_pva_exception(exception, state_enum):
     pv_name = "some_pv"
     serialiser = ep01_PVASerialiser(pv_name)
+
+    # First prime with a value update
+    serialiser.serialise(create_value_update(123))
+
+    # Now try the exception
     message, timestamp = serialiser.serialise(exception)
 
     fb_update = deserialise_ep01(message)

--- a/tests/update_handlers/ep01_serialiser_test.py
+++ b/tests/update_handlers/ep01_serialiser_test.py
@@ -103,6 +103,25 @@ def test_connected_to_exception_transition(exception, state_enum):
     assert fb_update.status == state_enum
 
 
+@pytest.mark.parametrize(
+    "exception,state_enum",
+    [
+        (Disconnected(), ConnectionInfo.DISCONNECTED),
+        (Cancelled(), ConnectionInfo.CANCELLED),
+        (Finished(), ConnectionInfo.FINISHED),
+        (RemoteError(), ConnectionInfo.REMOTE_ERROR),
+    ],
+)
+def test_if_never_connected_then_exceptions_returns_none(exception, state_enum):
+    pv_name = "some_pv"
+    serialiser = ep01_PVASerialiser(pv_name)
+
+    message, timestamp = serialiser.serialise(exception)
+
+    assert message is None
+    assert timestamp is None
+
+
 def test_serialise_nonsense_returns_unknown():
     pv_name = "some_pv"
     serialiser = ep01_PVASerialiser(pv_name)

--- a/tests/update_handlers/ep01_serialiser_test.py
+++ b/tests/update_handlers/ep01_serialiser_test.py
@@ -23,11 +23,7 @@ def _test_serialise_start(pv_name, serialiser):
     assert fb_update.status == ConnectionInfo.NEVER_CONNECTED
 
 
-<<<<<<< HEAD
 def _create_value_update(reference_timestamp):
-=======
-def create_value_update(reference_timestamp):
->>>>>>> 6749501 (added test that would have flagged bug and improved existing tests)
     test_data = np.array([-3, -2, -1]).astype(np.int32)
     update = NTScalar("ai").wrap(test_data)
     update.timeStamp.secondsPastEpoch = 0
@@ -42,7 +38,6 @@ def test_serialise_pva_start():
     return _test_serialise_start(pv_name, serialiser)
 
 
-<<<<<<< HEAD
 def test_if_disconnected_and_never_connected_returns_none():
     serialiser = ep01_PVASerialiser("some_pv")
 
@@ -50,24 +45,11 @@ def test_if_disconnected_and_never_connected_returns_none():
 
     assert message is None
     assert timestamp is None
-=======
-def test_if_disconnected_and_never_connected_send_never_connected():
-    serialiser = ep01_PVASerialiser("some_pv")
-
-    message, _ = serialiser.serialise(p4p.client.thread.Disconnected())
-
-    fb_update = deserialise_ep01(message)
-    assert fb_update.status == ConnectionInfo.NEVER_CONNECTED
->>>>>>> 6749501 (added test that would have flagged bug and improved existing tests)
 
 
 def test_serialise_pva_value():
     reference_timestamp = 10
-<<<<<<< HEAD
     update = _create_value_update(reference_timestamp)
-=======
-    update = create_value_update(reference_timestamp)
->>>>>>> 6749501 (added test that would have flagged bug and improved existing tests)
 
     pv_name = "some_pv"
     serialiser = ep01_PVASerialiser(pv_name)
@@ -82,11 +64,7 @@ def test_serialise_pva_value():
 
 def test_if_state_unchanged_then_message_is_none():
     reference_timestamp = 10
-<<<<<<< HEAD
     update = _create_value_update(reference_timestamp)
-=======
-    update = create_value_update(reference_timestamp)
->>>>>>> 6749501 (added test that would have flagged bug and improved existing tests)
     pv_name = "some_pv"
     serialiser = ep01_PVASerialiser(pv_name)
     # First update
@@ -113,11 +91,7 @@ def test_connected_to_exception_transition(exception, state_enum):
     serialiser = ep01_PVASerialiser(pv_name)
 
     # First prime with a value update
-<<<<<<< HEAD
     serialiser.serialise(_create_value_update(123))
-=======
-    serialiser.serialise(create_value_update(123))
->>>>>>> 6749501 (added test that would have flagged bug and improved existing tests)
 
     # Now try the exception
     message, timestamp = serialiser.serialise(exception)


### PR DESCRIPTION
For p4p the Value class was not in the map, so even if the PV was connected it appeared as unknown.
It is a one line fix, but I added a regression test for it and fixed up the related tests. 

If a PV never connected then it doesn't send anything to Kafka.