### PR TITLE
Metrics: Add kafka delivery error metric

### DIFF
--- a/forwarder/kafka/kafka_helpers.py
+++ b/forwarder/kafka/kafka_helpers.py
@@ -43,6 +43,7 @@ def create_producer(
     password: Optional[str] = None,
     counter: Optional[Counter] = None,
     buffer_err_counter: Optional[Counter] = None,
+    delivery_err_counter: Optional[Counter] = None,
 ) -> KafkaProducer:
     producer_config = {
         "bootstrap.servers": broker_address,
@@ -55,6 +56,7 @@ def create_producer(
         producer,
         update_msg_counter=counter,
         update_buffer_err_counter=buffer_err_counter,
+        update_delivery_err_counter=delivery_err_counter,
     )
 
 

--- a/forwarder/repeat_timer.py
+++ b/forwarder/repeat_timer.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 from threading import Lock, Timer
+
 from forwarder.application_logger import get_logger
 
 

--- a/forwarder/statistics_reporter.py
+++ b/forwarder/statistics_reporter.py
@@ -48,7 +48,9 @@ class StatisticsReporter:
                 "data_loss_errors", self._update_buffer_err_counter.value, timestamp
             )
             self._sender.send(
-                "kafka_delivery_errors", self._update_delivery_err_counter.value, timestamp
+                "kafka_delivery_errors",
+                self._update_delivery_err_counter.value,
+                timestamp,
             )
         except Exception as ex:
             self._logger.error(f"Could not send statistic: {ex}")

--- a/forwarder/statistics_reporter.py
+++ b/forwarder/statistics_reporter.py
@@ -17,6 +17,7 @@ class StatisticsReporter:
         update_handlers: Dict[Channel, UpdateHandler],
         update_msg_counter: Counter,
         update_buffer_err_counter: Counter,
+        update_delivery_err_counter: Counter,
         logger: Logger,
         prefix: str = "throughput",
         update_interval_s: int = 10,
@@ -25,6 +26,7 @@ class StatisticsReporter:
         self._update_handlers = update_handlers
         self._update_msg_counter = update_msg_counter
         self._update_buffer_err_counter = update_buffer_err_counter
+        self._update_delivery_err_counter = update_delivery_err_counter
         self._logger = logger
 
         self._sender = graphyte.Sender(self._graphyte_server, prefix=prefix)
@@ -44,6 +46,9 @@ class StatisticsReporter:
             )
             self._sender.send(
                 "data_loss_errors", self._update_buffer_err_counter.value, timestamp
+            )
+            self._sender.send(
+                "kafka_delivery_errors", self._update_delivery_err_counter.value, timestamp
             )
         except Exception as ex:
             self._logger.error(f"Could not send statistic: {ex}")

--- a/forwarder_launch.py
+++ b/forwarder_launch.py
@@ -25,7 +25,11 @@ from forwarder.utils import Counter
 
 
 def create_epics_producer(
-    broker_uri, broker_sasl_password, update_message_counter, update_buffer_err_counter, update_delivery_err_counter
+    broker_uri,
+    broker_sasl_password,
+    update_message_counter,
+    update_buffer_err_counter,
+    update_delivery_err_counter,
 ):
     (
         broker,

--- a/forwarder_launch.py
+++ b/forwarder_launch.py
@@ -25,7 +25,7 @@ from forwarder.utils import Counter
 
 
 def create_epics_producer(
-    broker_uri, broker_sasl_password, update_message_counter, update_buffer_err_counter
+    broker_uri, broker_sasl_password, update_message_counter, update_buffer_err_counter, update_delivery_err_counter
 ):
     (
         broker,
@@ -40,6 +40,7 @@ def create_epics_producer(
         broker_sasl_password,
         counter=update_message_counter,
         buffer_err_counter=update_buffer_err_counter,
+        delivery_err_counter=update_delivery_err_counter,
     )
     return producer
 
@@ -129,6 +130,7 @@ def create_statistics_reporter(
     update_handlers,
     update_message_counter,
     update_buffer_err_counter,
+    update_delivery_err_counter,
     logger,
     statistics_update_interval,
 ):
@@ -141,6 +143,7 @@ def create_statistics_reporter(
         update_handlers,
         update_message_counter,  # type: ignore
         update_buffer_err_counter,  # type: ignore
+        update_delivery_err_counter,  # type: ignore
         logger,
         prefix=prefix,
         update_interval_s=statistics_update_interval,
@@ -188,6 +191,7 @@ if __name__ == "__main__":
     grafana_carbon_address = args.grafana_carbon_address
     update_message_counter = Counter() if grafana_carbon_address else None
     update_buffer_err_counter = Counter() if grafana_carbon_address else None
+    update_delivery_err_counter = Counter() if grafana_carbon_address else None
 
     with ExitStack() as exit_stack:
 
@@ -197,6 +201,7 @@ if __name__ == "__main__":
             args.output_broker_sasl_password,
             update_message_counter,
             update_buffer_err_counter,
+            update_delivery_err_counter,
         )
         exit_stack.callback(producer.close)
 
@@ -223,6 +228,7 @@ if __name__ == "__main__":
                 update_handlers,
                 update_message_counter,
                 update_buffer_err_counter,
+                update_delivery_err_counter,
                 get_logger(),
                 args.statistics_update_interval,
             )

--- a/tests/statistic_reporter_test.py
+++ b/tests/statistic_reporter_test.py
@@ -2,6 +2,8 @@ import logging
 from typing import Dict
 from unittest.mock import ANY, MagicMock, call
 
+from confluent_kafka import KafkaError
+
 from forwarder.kafka.kafka_producer import KafkaProducer
 from forwarder.statistics_reporter import StatisticsReporter
 from forwarder.utils import Counter
@@ -14,7 +16,7 @@ buffer_err_counter = Counter()
 def test_that_warning_logged_on_send_exception(caplog):
     update_handler: Dict = {}
     statistics_reporter = StatisticsReporter(
-        "localhost", update_handler, Counter(), buffer_err_counter, logger
+        "localhost", update_handler, Counter(), buffer_err_counter, Counter(), logger
     )
     statistics_reporter._sender = MagicMock()
     statistics_reporter._sender.send.side_effect = ValueError
@@ -30,7 +32,7 @@ def test_statistic_reporter_sends_number_pvs():
     # This dictionary is of type Dict[Channel, UpdateHandler]
     # StatisticReporter only uses len of this dictionary
     update_handler = {"key1": "value1", "key2": "value2"}
-    statistics_reporter = StatisticsReporter("localhost", update_handler, update_msg_counter, buffer_err_counter, logger)  # type: ignore
+    statistics_reporter = StatisticsReporter("localhost", update_handler, update_msg_counter, buffer_err_counter, Counter(), logger)  # type: ignore
     statistics_reporter._sender = MagicMock()
 
     statistics_reporter.send_statistics()
@@ -44,7 +46,7 @@ def test_statistic_reporter_sends_number_pvs():
 def test_statistic_reporter_sends_total_updates():
     update_msg_counter: Counter = Counter()
     statistics_reporter = StatisticsReporter(
-        "localhost", {}, update_msg_counter, buffer_err_counter, logger
+        "localhost", {}, update_msg_counter, buffer_err_counter, Counter(), logger
     )
     statistics_reporter._sender = MagicMock()
 
@@ -99,10 +101,32 @@ def test_producer_increments_buffer_error_counter_on_buffer_error():
     assert update_buffer_err_counter.value == 1
 
 
+def test_producer_increments_delivery_error_counter_on_delivery_error():
+    class FakeProducer:
+        def produce(self, topic, payload, key, on_delivery, timestamp):
+            error = KafkaError(KafkaError.INVALID_CONFIG)
+            on_delivery(error, "some error message")
+
+        def flush(self, _):
+            pass
+
+        def poll(self, _):
+            pass
+
+    update_delivery_err_counter: Counter = Counter()
+    kafka_producer = KafkaProducer(
+        FakeProducer(), update_delivery_err_counter=update_delivery_err_counter
+    )
+
+    kafka_producer.produce("IRRELEVANT_TOPIC", b"IRRELEVANT_PAYLOAD", 0, key="PV_NAME")
+    kafka_producer.close()
+    assert update_delivery_err_counter.value == 1
+
+
 def test_statistic_reporter_sends_data_loss_errors():
     update_buffer_err_counter: Counter = Counter()
     statistics_reporter = StatisticsReporter(
-        "localhost", {}, Counter(), update_buffer_err_counter, logger
+        "localhost", {}, Counter(), update_buffer_err_counter, Counter(), logger
     )
     statistics_reporter._sender = MagicMock()
 
@@ -113,5 +137,23 @@ def test_statistic_reporter_sends_data_loss_errors():
 
     calls = [
         call("data_loss_errors", 3, ANY),
+    ]
+    statistics_reporter._sender.send.assert_has_calls(calls, any_order=True)
+
+
+def test_statistic_reporter_sends_delivery_errors():
+    update_delivery_err_counter: Counter = Counter()
+    statistics_reporter = StatisticsReporter(
+        "localhost", {}, Counter(), Counter(), update_delivery_err_counter, logger
+    )
+    statistics_reporter._sender = MagicMock()
+
+    update_delivery_err_counter.increment()
+    update_delivery_err_counter.increment()
+    update_delivery_err_counter.increment()
+    statistics_reporter.send_statistics()
+
+    calls = [
+        call("kafka_delivery_errors", 3, ANY),
     ]
     statistics_reporter._sender.send.assert_has_calls(calls, any_order=True)


### PR DESCRIPTION
We currently report metrics on "data loss errors" by detecting if the producer buffer is full.

This PR adds an additional metric `kafka_delivery_errors`. These errors are produced when the Kafka producer **permanently** fails delivery of a message.
Delivery errors may eventually be captured by the existing "data loss errors" metric, but the new metric is a more direct way of capturing them, and can probably capture other errors ignored until now.