### PR TITLE
[Partial Fix] setup via pyproject.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ dmypy.json
 .idea
 integration_tests/logs/*.log
 .vscode
+
+# setuptools-scm generated version file:
+_version.py

--- a/forwarder/parse_commandline_args.py
+++ b/forwarder/parse_commandline_args.py
@@ -22,12 +22,28 @@ class VersionArgParser(configargparse.ArgumentParser):
 
 def get_version() -> str:
     """
-    Gets the current version from the pyproject file
+    Gets the current version from the setuptools-scm generated _version.py file
     """
-    path = Path(__file__).parent.parent / "pyproject.toml"
-    with open(path, "rb") as file:
-        config = tomli.load(file)
-    return str(config["project"]["version"])
+    v = None
+    try:
+        from ._version import version
+        v = version
+    except ImportError:
+        pass
+    if v is None:
+        try:
+            from setuptools_scm import get_version
+            v = get_version()
+        except ImportError:
+            # no setuptools_scm or package layout has changed?
+            pass
+        except LookupError:
+            # Running from outside of a git repository or PyPI tarball
+            pass
+    if v is None:
+        v = 'development'
+
+    return v
 
 
 def _print_version_if_requested():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dynamic = ["version"]
 packages = ["forwarder"]
 
 [tool.setuptools_scm]
+write_to = "forwarder/_version.py"
 
 [tool.black]
 exclude = '/(venv*|.tox)'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,19 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "forwarder"
-version = "development"
-homepage = "https://github.com/ess-dmsc/forwarder"
-repository = "https://github.com/ess-dmsc/forwarder"
+urls = {homepage="https://github.com/ess-dmsc/forwarder", repository="https://github.com/ess-dmsc/forwarder"}
 license = { file="LICENSE" }
-readme = {file = ["README.md"]}
+readme = "README.md"
 requires-python = ">=3.8"
+dynamic = ["version"]
+
+[tool.setuptools]
+packages = ["forwarder"]
+
+[tool.setuptools_scm]
 
 [tool.black]
 exclude = '/(venv*|.tox)'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,17 @@ license = { file="LICENSE" }
 readme = "README.md"
 requires-python = ">=3.8"
 dynamic = ["version"]
+dependencies = [
+    "caproto == 1.0.1",
+		"p4p == 4.1.5",
+		"confluent_kafka == 2.1.0",
+    "graypy == 2.1.0",
+    "graphyte == 1.7.1",
+    "numpy >= 1.19",
+    "ConfigArgParse == 1.5.3",
+    "ess-streaming-data-types == 0.21.1",
+    "tomli == 2.0.1",
+]
 
 [tool.setuptools]
 packages = ["forwarder"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ graypy == 2.1.0
 graphyte == 1.7.1
 numpy >= 1.19
 ConfigArgParse == 1.5.3
-ess-streaming-data-types == 0.21.0
+ess-streaming-data-types == 0.21.1
 tomli==2.0.1


### PR DESCRIPTION
## Issue
As described in #249 this package is not pip-installable.

## Description of work
These changes are sufficient to get the package installed. The installed package may need its requirements installed separately, so an improved solution would add the dependencies to `pyproject.toml` directly.

## Checklist

- [ ] Pre-commit hooks have been run (see https://github.com/ess-dmsc/forwarder#developer-information)
- [ ] Changes have been documented in `changes.md`
