### PR TITLE
Update kafka_helpers.py

### DIFF
--- a/forwarder/kafka/kafka_helpers.py
+++ b/forwarder/kafka/kafka_helpers.py
@@ -72,7 +72,7 @@ def create_producer(
             get_sasl_config(security_protocol, sasl_mechanism, username, password)
         )
         if ssl_ca_file:
-            producer_config["ssl_cafile"] = ssl_ca_file
+            producer_config["ssl.ca.location"] = ssl_ca_file
     producer = Producer(producer_config)
     return KafkaProducer(
         producer,
@@ -100,7 +100,7 @@ def create_consumer(
             get_sasl_config(security_protocol, sasl_mechanism, username, password)
         )
         if ssl_ca_file:
-            consumer_config["ssl_cafile"] = ssl_ca_file
+            consumer_config["ssl.ca.location"] = ssl_ca_file
     return Consumer(consumer_config)
 
 


### PR DESCRIPTION
Fix config name for SSL cert

Had used configuration parameter name for kafka-python by mistake.

## Issue

n/a

## Description of work

Fix configuration of SSL CA certificate location.

## Checklist

- [x] Pre-commit hooks have been run (see https://github.com/ess-dmsc/forwarder#developer-information)
- [x] Changes have been documented in `changes.md`
