### PR TITLE
Fix pyyaml build issues

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,6 +12,3 @@ black==23.3.0
 flake8==6.0.0
 mypy==v0.991
 isort==5.12.0
-
-# For integration tests
-docker-compose


### PR DESCRIPTION
## Issue

ECDC-3555

Since the release of cython v3 all our builds are failing.

This is related to an issue in pyyaml (see  https://github.com/yaml/pyyaml/issues/601).
We depend on pyyaml only because these development requirements:
- pre-commit
- docker-compose (this one is holding back a pyyaml upstream fix. The docker-compose installable via pip is only v1 from 2021, as Docker-Compose v2 is written in golang :snake:)

## Description of work

- Fix the issue by completely removing docker-compose as a dependency. Developers needs to install docker compose independently.
- Remove `docker` and `pytictoc` dependencies, as I see no code importing those packages.



## Checklist

- [X] Pre-commit hooks have been run (see https://github.com/ess-dmsc/forwarder#developer-information)
- [ ] Changes have been documented in `changes.md`
