### PR TITLE
Add option for status interval

### DIFF
--- a/forwarder/parse_commandline_args.py
+++ b/forwarder/parse_commandline_args.py
@@ -183,6 +183,14 @@ def parse_args():
         type=int,
         default=1000,
     )
+    parser.add_argument(
+        "--status-interval",
+        help="Period for status updates (units=milliseconds)",
+        required=False,
+        env_var="STATUS_INTERVAL",
+        type=int,
+        default=4000,
+    )
     log_choice_to_enum = {
         "Trace": logging.DEBUG,
         "Debug": logging.DEBUG,

--- a/forwarder/scripts/run.py
+++ b/forwarder/scripts/run.py
@@ -81,6 +81,7 @@ def create_status_reporter(
     service_id,
     version,
     logger,
+    status_interval,
 ):
     (
         broker,
@@ -107,6 +108,7 @@ def create_status_reporter(
         service_id,
         version,
         logger,
+        status_interval,
     )
     return status_reporter
 
@@ -249,6 +251,7 @@ def main():
             args.service_id,
             version,
             get_logger(),
+            args.status_interval,
         )
         exit_stack.callback(status_reporter.stop)
         status_reporter.start()

--- a/forwarder/status_reporter.py
+++ b/forwarder/status_reporter.py
@@ -22,7 +22,7 @@ class StatusReporter:
         service_id: str,
         version: str,
         logger: Logger,
-        interval_ms: int = 4000,
+        interval_ms: int,
     ):
         self._repeating_timer = RepeatTimer(
             milliseconds_to_seconds(interval_ms), self.report_status

--- a/tests/status_reporter_test.py
+++ b/tests/status_reporter_test.py
@@ -24,7 +24,7 @@ def test_when_update_handlers_exist_their_channel_names_are_reported_in_status()
     }
 
     fake_producer = FakeProducer()
-    status_reporter = StatusReporter(update_handlers, fake_producer, "status_topic", "", "version", logger)  # type: ignore
+    status_reporter = StatusReporter(update_handlers, fake_producer, "status_topic", "", "version", logger, 4000)  # type: ignore
     status_reporter.report_status()
 
     if fake_producer.published_payloads:
@@ -43,7 +43,7 @@ def test_when_no_update_handlers_exist_no_streams_are_present_in_reported_status
     update_handlers: Dict = {}
 
     fake_producer = FakeProducer()
-    status_reporter = StatusReporter(update_handlers, fake_producer, "status_topic", "", "version", logger)  # type: ignore
+    status_reporter = StatusReporter(update_handlers, fake_producer, "status_topic", "", "version", logger, 4000)  # type: ignore
     status_reporter.report_status()
 
     if fake_producer.published_payloads:
@@ -59,7 +59,7 @@ def test_status_message_contains_service_id():
     update_handlers: Dict = {}
 
     fake_producer = FakeProducer()
-    status_reporter = StatusReporter(update_handlers, fake_producer, "status_topic", service_id, "version", logger)  # type: ignore
+    status_reporter = StatusReporter(update_handlers, fake_producer, "status_topic", service_id, "version", logger, 4000)  # type: ignore
     status_reporter.report_status()
 
     if fake_producer.published_payloads:


### PR DESCRIPTION
## Issue

None

## Description of work

This PR adds an optional argument to the forwarder to specify its status logging interval. by default it's still 4000ms. 

At ISIS we need this as our status messages are forming the bulk of the space on Kafka as we have lots of PVs to forward, so we're reducing status updates to 30s. 

## Checklist

- [ ] Pre-commit hooks have been run (see https://github.com/ess-dmsc/forwarder#developer-information)
- [ ] Changes have been documented in `changes.md`
