### PR TITLE
forward units using un00 schema

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -6,6 +6,7 @@
 * Adopt pip-tools to manage requirements.txt files
 * Refactor statistics reporter to support dynamically added metrics
 * Add latency and per-PV graphite metrics
+* add support for streaming PV units (`un00` schema)
 
 ## v2.1.0
 

--- a/forwarder/update_handlers/schema_serialiser_factory.py
+++ b/forwarder/update_handlers/schema_serialiser_factory.py
@@ -28,6 +28,7 @@ from forwarder.update_handlers.tdct_serialiser import (
     tdct_CASerialiser,
     tdct_PVASerialiser,
 )
+from forwarder.update_handlers.un00_serialiser import un00_PVASerialiser, un00_CASerialiser
 
 
 class SerialiserFactory:
@@ -39,6 +40,7 @@ class SerialiserFactory:
             "f144": f144_CASerialiser,
             "no_op": no_op_CASerialiser,
             "tdct": tdct_CASerialiser,
+            "un00": un00_CASerialiser,
         },
         EpicsProtocol.FAKE: {
             "al00": al00_PVASerialiser,
@@ -49,6 +51,7 @@ class SerialiserFactory:
             "nttable_se00": nttable_se00_PVASerialiser,
             "nttable_senv": nttable_senv_PVASerialiser,
             "tdct": tdct_PVASerialiser,
+            "un00": un00_PVASerialiser,
         },
         EpicsProtocol.PVA: {
             "al00": al00_PVASerialiser,
@@ -59,6 +62,7 @@ class SerialiserFactory:
             "nttable_se00": nttable_se00_PVASerialiser,
             "nttable_senv": nttable_senv_PVASerialiser,
             "tdct": tdct_PVASerialiser,
+            "un00": un00_PVASerialiser,
         },
     }
 

--- a/forwarder/update_handlers/serialiser_tracker.py
+++ b/forwarder/update_handlers/serialiser_tracker.py
@@ -99,18 +99,18 @@ class SerialiserTracker:
         message_datetime = datetime.fromtimestamp(timestamp_ns / 1e9, tz=timezone.utc)
         if message_datetime < self._last_timestamp:
             self._logger.error(
-                f"Rejecting update on {self._pv_name} as its timestamp is older than the previous message timestamp from that PV ({message_datetime} vs {self._last_timestamp})."
+                f"Rejecting update on {self._pv_name} as its timestamp({message_datetime}) is older than the previous message timestamp from that PV ({message_datetime} vs {self._last_timestamp})."
             )
             return
         current_datetime = datetime.now(tz=timezone.utc)
         if message_datetime < current_datetime - LOWER_AGE_LIMIT:
             self._logger.error(
-                f"Rejecting update on {self._pv_name} as its timestamp is older than allowed ({LOWER_AGE_LIMIT})."
+                f"Rejecting update on {self._pv_name} as its timestamp({message_datetime}) is older than allowed ({LOWER_AGE_LIMIT})."
             )
             return
         if message_datetime > current_datetime + UPPER_AGE_LIMIT:
             self._logger.error(
-                f"Rejecting update on {self._pv_name} as its timestamp is from further into the future than allowed ({UPPER_AGE_LIMIT})."
+                f"Rejecting update on {self._pv_name} as its timestamp({message_datetime}) is from further into the future than allowed ({UPPER_AGE_LIMIT})."
             )
             return
         self._last_timestamp = message_datetime
@@ -176,6 +176,16 @@ def create_serialiser_list(
     return_list.append(
         SerialiserTracker(
             SerialiserFactory.create_serialiser(protocol, "ep01", pv_name),
+            producer,
+            pv_name,
+            output_topic,
+            periodic_update_ms,
+        )
+    )
+    # Units serialiser
+    return_list.append(
+        SerialiserTracker(
+            SerialiserFactory.create_serialiser(protocol, "un00", pv_name),
             producer,
             pv_name,
             output_topic,

--- a/forwarder/update_handlers/un00_serialiser.py
+++ b/forwarder/update_handlers/un00_serialiser.py
@@ -1,0 +1,72 @@
+from typing import Optional, Tuple, Union
+import p4p
+from caproto import Message as CA_Message
+
+from forwarder.application_logger import get_logger
+from streaming_data_types import serialise_un00
+
+from forwarder.kafka.kafka_helpers import seconds_to_nanoseconds
+from forwarder.update_handlers.schema_serialisers import CASerialiser, PVASerialiser
+
+logger = get_logger()
+
+def _serialise(
+    source_name: str,
+    timestamp_ns: int | None,
+    units: str | None,
+) -> Tuple[bytes, int]:
+    return (
+        serialise_un00(source_name, timestamp_ns, units),
+        timestamp_ns,
+    )
+
+
+class un00_CASerialiser(CASerialiser):
+    def __init__(self, source_name: str):
+        self._source_name = source_name
+        self._message: Optional[str] = None
+        self._units: Optional[str] = None
+
+    def serialise(
+        self, update: CA_Message, **unused
+    ) -> Union[Tuple[bytes, int], Tuple[None, None]]:
+        metadata = update.metadata
+        try:
+            timestamp = seconds_to_nanoseconds(metadata.timestamp)
+        except AttributeError:
+            logger.warning("No timestamp available for %s", self._source_name)
+            timestamp = None
+        try:
+            units = metadata.units
+        except AttributeError:
+            logger.warning("No units available for %s", self._source_name)
+            return [None, None]
+        logger.debug(f"Source name: {self._source_name}, timestamp: {timestamp}, units: {units}")
+        return _serialise(self._source_name, timestamp, units)
+
+    def conn_serialise(self, pv: str, state: str) -> Tuple[None, None]:
+        return None, None
+
+
+class un00_PVASerialiser(PVASerialiser):
+    def __init__(self, source_name: str):
+        self._source_name = source_name
+        self._message: Optional[str] = None
+        self._units: Optional[str] = None
+
+    def serialise(
+        self, update: Union[p4p.Value, RuntimeError]
+    ) -> Union[Tuple[bytes, int], Tuple[None, None]]:
+        if isinstance(update, RuntimeError):
+            return None, None
+        timestamp = (
+            update.timeStamp.secondsPastEpoch * 1_000_000_000
+        ) + update.timeStamp.nanoseconds
+
+        try:
+            self._units = update.display.units
+        except AttributeError:
+            logger.warning("No units available for %s", self._source_name)
+            self._units = None
+
+        return _serialise(self._source_name, timestamp, self._units)

--- a/tests/test_helpers/ca_fakes.py
+++ b/tests/test_helpers/ca_fakes.py
@@ -45,6 +45,7 @@ class FakeContext:
         return [FakePV(pv_name, self.subscription) for pv_name in pv_names]
 
     def call_monitor_callback_with_fake_pv_update(self, pv_update: ReadNotifyResponse):
+        # This actually calls both the monitor and unit callbacks.
         for c in self.subscription.callback:
             c(self.subscription, pv_update)
 


### PR DESCRIPTION
## Issue

None, discussed in streaming catchup. 

## Description of work

Adds support for streaming engineering units, in the form of the `un00` schema, on PV updates. 

logic here is: 

- on initial message with blank units, sends blank update.
- on initial message with no EGU field at all (ie an mbbi), sends no update.
- on updated units, sends update.

with PVA this is fairly easy, with CA it's a bit of a nightmare as you don't get timestamped CTRL updates which means you either have to use the last pv update, or if that doesn't exist then use the current time (which might be slightly after) - as they seldom change this isn't much of an issue. 

## Checklist

- [ ] Pre-commit hooks have been run (see https://github.com/ess-dmsc/forwarder#developer-information)
- [ ] Changes have been documented in `changes.md`
